### PR TITLE
Make `mcp` an optional dep.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,7 +28,7 @@ jobs:
           cache: "pip"
 
       - name: Install
-        run: pip install -e '.[langchain,smolagents,openai,tests]'
+        run: pip install -e '.[mcp,langchain,smolagents,openai,tests]'
 
       - name: Run Unit tests
         run: pytest -v tests/unit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ dependencies = [
   "fire",
   "loguru",
   "markdownify",
-  "mcp>=1.5.0",
   "opentelemetry-exporter-otlp",
   "opentelemetry-sdk",
   "pydantic",
@@ -36,6 +35,10 @@ smolagents = [
 openai = [
   "openai-agents>=0.0.7",
   "openinference-instrumentation-openai-agents"
+]
+
+mcp = [
+  "mcp>=1.5.0"
 ]
 
 docs = [

--- a/src/any_agent/tools/mcp.py
+++ b/src/any_agent/tools/mcp.py
@@ -6,9 +6,16 @@ import asyncio
 from loguru import logger
 from textwrap import dedent
 
-from mcp import ClientSession, StdioServerParameters
-from mcp.client.stdio import stdio_client
 from any_agent.config import MCPTool
+
+try:
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    mcp_available = True
+except ImportError:
+    mcp_available = False
+
 
 # Global registry to keep manager instances alive
 _mcp_managers = {}
@@ -18,6 +25,8 @@ class MCPToolsManagerBase(ABC):
     """Base class for MCP tools managers across different frameworks."""
 
     def __init__(self, mcp_tool: MCPTool):
+        if not mcp_available:
+            raise ImportError("You need to `pip install mcp` to use this tools.")
         # Generate a unique identifier for this manager instance
         self.id = id(self)
 


### PR DESCRIPTION
Since it is not expected to be used by default and it is kind of heavy (brings `starlette`, `uvicorn`, etc).