### PR TITLE
enh(config): Updates to allow passing arbitrary args to agent and model.

### DIFF
--- a/src/any_agent/agents/langchain.py
+++ b/src/any_agent/agents/langchain.py
@@ -55,12 +55,21 @@ class LangchainAgent(AnyAgent):
 
         if "/" in self.config.model_id:
             model_provider, model_id = self.config.model_id.split("/")
-            model = init_chat_model(model=model_id, model_provider=model_provider)
+            model = init_chat_model(
+                model=model_id,
+                model_provider=model_provider,
+                **self.config.model_args or {},
+            )
         else:
-            model = init_chat_model(self.config.model_id)
+            model = init_chat_model(
+                self.config.model_id, **self.config.model_args or {}
+            )
 
         self._agent: CompiledGraph = create_react_agent(
-            model=model, tools=imported_tools, prompt=self.config.instructions
+            model=model,
+            tools=imported_tools,
+            prompt=self.config.instructions,
+            **self.config.agent_args or {},
         )
         # Langgraph doesn't let you easily access what tools are loaded from the CompiledGraph, so we'll store a list of them in this class
         self._tools = imported_tools

--- a/src/any_agent/agents/llama_index.py
+++ b/src/any_agent/agents/llama_index.py
@@ -31,14 +31,14 @@ class LlamaIndexAgent(AnyAgent):
 
     def _get_model(self, agent_config: AgentConfig):
         """Get the model configuration for a llama_index agent."""
-        if not agent_config.model_class:
-            agent_config.model_class = DEFAULT_MODEL_CLASS
-        module, class_name = agent_config.model_class.split(".")
-        model_class = getattr(
+        if not agent_config.model_type:
+            agent_config.model_type = DEFAULT_MODEL_CLASS
+        module, class_name = agent_config.model_type.split(".")
+        model_type = getattr(
             importlib.import_module(f"llama_index.llms.{module}"), class_name
         )
 
-        return model_class(model=agent_config.model_id)
+        return model_type(model=agent_config.model_id, **agent_config.model_args or {})
 
     @logger.catch(reraise=True)
     def _load_agent(self) -> None:
@@ -69,6 +69,7 @@ class LlamaIndexAgent(AnyAgent):
             name=self.config.name,
             tools=imported_tools,
             llm=self._get_model(self.config),
+            **self.config.agent_args or {},
         )
 
     async def _async_run(self, prompt):

--- a/src/any_agent/config.py
+++ b/src/any_agent/config.py
@@ -20,10 +20,10 @@ class AgentConfig(BaseModel):
     model_id: str
     name: str = "default-name"
     instructions: str | None = None
-    api_base: str | None = None
-    api_key_var: str | None = None
     tools: list[str | MCPTool] = Field(default_factory=list)
     handoff: bool = False
     agent_type: str | None = None
-    model_class: str | None = None
+    agent_args: dict | None = None
+    model_type: str | None = None
+    model_args: dict | None = None
     description: str | None = None

--- a/tests/unit/agents/test_openai.py
+++ b/tests/unit/agents/test_openai.py
@@ -45,7 +45,10 @@ def test_openai_with_api_base_and_api_key_var():
     ):
         AnyAgent.create(
             AgentFramework.OPENAI,
-            AgentConfig(model_id="gpt-4o", api_base="FOO", api_key_var="TEST_API_KEY"),
+            AgentConfig(
+                model_id="gpt-4o",
+                model_args=dict(base_url="FOO", api_key_var="TEST_API_KEY"),
+            ),
         )
         async_openai_mock.assert_called_once_with(
             api_key="test-key-12345",
@@ -60,7 +63,8 @@ def test_openai_environment_error():
             AnyAgent.create(
                 AgentFramework.OPENAI,
                 AgentConfig(
-                    model_id="gpt-4o", api_base="FOO", api_key_var="MISSING_KEY"
+                    model_id="gpt-4o",
+                    model_args=dict(base_url="FOO", api_key_var="MISSING_KEY"),
                 ),
             )
 

--- a/tests/unit/agents/test_smolagents.py
+++ b/tests/unit/agents/test_smolagents.py
@@ -50,8 +50,10 @@ def test_load_smolagent_with_api_base_and_api_key_var():
             AgentFramework.SMOLAGENTS,
             AgentConfig(
                 model_id="openai/o3-mini",
-                api_base="https://custom-api.example.com",
-                api_key_var="OPENAI_API_KEY",
+                model_args=dict(
+                    api_base="https://custom-api.example.com",
+                    api_key_var="OPENAI_API_KEY",
+                ),
             ),
         )
         mock_agent.assert_called_once_with(
@@ -81,7 +83,10 @@ def test_load_smolagent_environment_error():
         with pytest.raises(KeyError, match="MISSING_KEY"):
             AnyAgent.create(
                 AgentFramework.SMOLAGENTS,
-                AgentConfig(model_id="openai/o3-mini", api_key_var="MISSING_KEY"),
+                AgentConfig(
+                    model_id="openai/o3-mini",
+                    model_args=dict(api_key_var="MISSING_KEY"),
+                ),
             )
 
 


### PR DESCRIPTION
Drop `api_base` and `api_key_var`.
Rename `model_class` to `model_type` for consistency with `agent_type`.

Closes #3

Tested `temperature` in surf-spot-finder with:

```yaml
location: Pontevedra
date: 2025-04-02 12:00
max_driving_hours: 2

framework: smolagents

main_agent:
  model_id: openai/gpt-4o
  model_args:
    temperature: 0
```

You can actually switch to `o3-mini` and it will break with openai exception because temperature can't be set to 0.