### PR TITLE
enh(instructions): Automatically detect imports.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -6,4 +6,6 @@
 
 ::: any_agent.agents
 
+::: any_agent.instructions
+
 ::: any_agent.tools

--- a/src/any_agent/instructions/imports.py
+++ b/src/any_agent/instructions/imports.py
@@ -1,10 +1,40 @@
 import importlib
+import re
+
+
+def is_import(instructions):
+    pattern = r"^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*$"
+    return bool(re.match(pattern, instructions))
 
 
 def get_instructions(instructions: str | None) -> str | None:
-    if instructions and instructions.startswith("import::"):
-        _, full_path = instructions.lstrip("import::")
-        module, obj = full_path.rsplit(".", 1)
+    """Get the instructions from an external module.
+
+    Args:
+        instructions: Depending on the syntax used:
+
+            - An import that points to a string in an external module.
+                For example: `agents.extensions.handoff_prompt.RECOMMENDED_PROMPT_PREFIX`.
+                The string will be imported from the external module.
+
+            - A regular string containing instructions.
+                For example: `You are a helpful assistant`.
+                The string will be returned as is.
+
+    Returns:
+        Either the imported string or the input string as is.
+
+    Raises:
+        ValueError: If `instructions` is an import but doesn't point to a string.
+    """
+    if instructions and is_import(instructions):
+        module, obj = instructions.rsplit(".", 1)
         module = importlib.import_module(module)
-        return getattr(module, obj)
+        imported = getattr(module, obj)
+        if not isinstance(imported, str):
+            raise ValueError(
+                "Instructions were identified as an import"
+                f" but the value imported is not a string:  {instructions}"
+            )
+        return imported
     return instructions

--- a/tests/unit/test_unit_instructions.py
+++ b/tests/unit/test_unit_instructions.py
@@ -1,0 +1,27 @@
+import pytest
+
+from any_agent.instructions import get_instructions
+
+
+def test_get_instructions_string():
+    instructions = "You are a helpful assistant"
+    result = get_instructions(instructions)
+    assert result == instructions
+
+
+def test_get_instructions_import():
+    instructions = "agents.extensions.handoff_prompt.RECOMMENDED_PROMPT_PREFIX"
+    result = get_instructions(instructions)
+    assert result.startswith("# System context\nYou are part of a multi-agent system")
+
+
+def test_get_instructions_import_error():
+    instructions = "agents.extensions.fake_module.RECOMMENDED_PROMPT_PREFIX"
+    with pytest.raises(ImportError):
+        get_instructions(instructions)
+
+
+def test_get_instructions_value_error():
+    instructions = "any_agent.AnyAgent"
+    with pytest.raises(ValueError, match="Instructions were identified as an import"):
+        get_instructions(instructions)


### PR DESCRIPTION
Instead of requiring `import::` syntax.