### PR TITLE
integration test for mcp, clean up code

### DIFF
--- a/src/any_agent/config.py
+++ b/src/any_agent/config.py
@@ -18,7 +18,7 @@ class MCPTool(BaseModel):
 class AgentConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
     model_id: str
-    name: str = "default-name"
+    name: str = "any_agent"
     instructions: str | None = None
     tools: list[str | MCPTool] = Field(default_factory=list)
     handoff: bool = False

--- a/src/any_agent/frameworks/openai.py
+++ b/src/any_agent/frameworks/openai.py
@@ -124,7 +124,20 @@ class OpenAIAgent(AnyAgent):
         Return the tools used by the agent.
         This property is read-only and cannot be modified.
         """
-        if hasattr(self, "_agent") and hasattr(self._agent, "tools"):
+        if hasattr(self, "_agent"):
             # Extract tool names from the agent's tools
-            return [tool.name for tool in self._agent.tools if hasattr(tool, "name")]
-        return []
+            tools = [tool.name for tool in self._agent.tools]
+            # Add MCP tools to the list
+            for mcp_server in self._agent.mcp_servers:
+                tools_in_mcp = mcp_server._tools_list
+                server_name = mcp_server.name.replace(" ", "_")
+                if tools_in_mcp:
+                    tools.extend(
+                        [f"{server_name}_{tool.name}" for tool in tools_in_mcp]
+                    )
+                else:
+                    raise ValueError(f"No tools found in MCP {server_name}")
+        else:
+            logger.warning("Agent not loaded or does not have tools.")
+            tools = []
+        return tools

--- a/src/any_agent/tools/mcp.py
+++ b/src/any_agent/tools/mcp.py
@@ -74,7 +74,9 @@ class SmolagentsMCPToolsManager(MCPToolsManagerBase):
         )
 
         # Store the context manager itself
-        self.context = ToolCollection.from_mcp(self.server_parameters)
+        self.context = ToolCollection.from_mcp(
+            self.server_parameters, trust_remote_code=True
+        )
         # Enter the context
         self.tool_collection = self.context.__enter__()
         tools = self.tool_collection.tools
@@ -131,6 +133,9 @@ class OpenAIMCPToolsManager(MCPToolsManagerBase):
         self.loop.run_until_complete(self.server.__aenter__())
         # Get tools from the server
         self.tools = self.loop.run_until_complete(self.server.list_tools())
+        logger.warning(
+            "OpenAI MCP currently does not support filtering MCP available tools"
+        )
 
     def cleanup(self):
         self.server = None

--- a/src/any_agent/tools/wrappers.py
+++ b/src/any_agent/tools/wrappers.py
@@ -6,7 +6,6 @@ from any_agent.config import AgentFramework, MCPTool
 from any_agent.tools.mcp import (
     SmolagentsMCPToolsManager,
     OpenAIMCPToolsManager,
-    LangchainMCPToolsManager,
     MCPToolsManagerBase,
 )
 
@@ -55,7 +54,6 @@ def wrap_mcp_server(
     manager_map = {
         AgentFramework.OPENAI: OpenAIMCPToolsManager,
         AgentFramework.SMOLAGENTS: SmolagentsMCPToolsManager,
-        AgentFramework.LANGCHAIN: LangchainMCPToolsManager,
     }
 
     if agent_framework not in manager_map:
@@ -64,7 +62,7 @@ def wrap_mcp_server(
         )
 
     # Create the manager instance which will manage the MCP tool context
-    manager_class = manager_map[agent_framework]
+    manager_class: MCPToolsManagerBase = manager_map[agent_framework]
     manager = manager_class(mcp_tool)
 
     return manager

--- a/tests/integration/test_mcp.py
+++ b/tests/integration/test_mcp.py
@@ -1,0 +1,54 @@
+import os
+import tempfile as tmpfile
+import pytest
+
+from any_agent import AgentFramework, AgentConfig, AnyAgent
+
+
+@pytest.mark.parametrize(
+    "framework",
+    (AgentFramework.OPENAI, AgentFramework.SMOLAGENTS),
+)
+@pytest.mark.skipif(
+    "OPENAI_API_KEY" not in os.environ,
+    reason="Integration tests require `OPENAI_API_KEY` env var",
+)
+def test_load_and_run_agent(framework):
+    agent_framework = AgentFramework(framework)
+    kwargs = {}
+
+    tmp_dir = tmpfile.mkdtemp()
+    tools = [
+        {
+            "command": "docker",
+            "args": [
+                "run",
+                "-i",
+                "--rm",
+                "--mount",
+                f"type=bind,src={tmp_dir},dst=/projects",
+                "mcp/filesystem",
+                "/projects",
+            ],
+            "tools": [
+                "write_file",
+            ],
+        }
+    ]
+    agent_config = AgentConfig(
+        model_id="gpt-4o",
+        tools=tools,
+        **kwargs,
+    )
+    agent = AnyAgent.create(agent_framework, agent_config)
+    assert len(agent.tools) > 0
+    result = agent.run("Write 'hi' to /projects/tmp.txt")
+    # Check if the file was created
+    assert os.path.exists(os.path.join(tmp_dir, "tmp.txt"))
+    # Check if the content is correct
+    with open(os.path.join(tmp_dir, "tmp.txt"), "r") as f:
+        content = f.read()
+    assert content == "hi"
+    assert result
+    # remove the temporary directory
+    os.remove(os.path.join(tmp_dir, "tmp.txt"))

--- a/tests/unit/frameworks/test_llama_index.py
+++ b/tests/unit/frameworks/test_llama_index.py
@@ -25,7 +25,7 @@ def test_load_llama_index_agent_default():
         AnyAgent.create(AgentFramework.LLAMAINDEX, AgentConfig(model_id="gpt-4o"))
         model_mock.assert_called_once_with(model="gpt-4o")
         create_mock.assert_called_once_with(
-            name="default-name",
+            name="any_agent",
             llm=model_mock.return_value,
             tools=[tool_mock(search_web), tool_mock(visit_webpage)],
         )

--- a/tests/unit/frameworks/test_openai.py
+++ b/tests/unit/frameworks/test_openai.py
@@ -21,7 +21,7 @@ def test_load_openai_default():
     ):
         AnyAgent.create(AgentFramework.OPENAI, AgentConfig(model_id="gpt-4o"))
         mock_agent.assert_called_once_with(
-            name="default-name",
+            name="any_agent",
             model="gpt-4o",
             instructions=None,
             handoffs=[],
@@ -98,7 +98,7 @@ def test_load_openai_with_mcp_server():
 
         # Verify Agent was called with the MCP server
         mock_agent.assert_called_once_with(
-            name="default-name",
+            name="any_agent",
             model="gpt-4o",
             instructions=None,
             handoffs=[],
@@ -172,7 +172,7 @@ def test_load_openai_multiagent():
         mock_agent.assert_any_call(
             model="o3-mini",
             instructions=None,
-            name="default-name",
+            name="any_agent",
             handoffs=[mock_agent.return_value],
             tools=[
                 mock_agent.return_value.as_tool.return_value,

--- a/tests/unit/frameworks/test_smolagents.py
+++ b/tests/unit/frameworks/test_smolagents.py
@@ -27,7 +27,7 @@ def test_load_smolagent_default():
             ),
         )
         mock_agent.assert_called_once_with(
-            name="default-name",
+            name="any_agent",
             model=mock_model.return_value,
             managed_agents=[],
             tools=[mock_tool(search_web), mock_tool(visit_webpage)],
@@ -57,7 +57,7 @@ def test_load_smolagent_with_api_base_and_api_key_var():
             ),
         )
         mock_agent.assert_called_once_with(
-            name="default-name",
+            name="any_agent",
             model=mock_model.return_value,
             managed_agents=[],
             tools=[mock_tool(search_web), mock_tool(visit_webpage)],


### PR DESCRIPTION
The new smolagents lib doesn't accept a agent name that has a '-' in it, so I had to rename 'default-name' to 'any_agents'