### PR TITLE
MCPToolsManager -> MCPServer

### DIFF
--- a/src/any_agent/tools/mcp.py
+++ b/src/any_agent/tools/mcp.py
@@ -21,7 +21,7 @@ except ImportError:
 _smolagents_mcp_managers = {}
 
 
-class MCPToolsManagerBase(ABC):
+class MCPServerBase(ABC):
     """Base class for MCP tools managers across different frameworks."""
 
     def __init__(self, mcp_tool: MCPTool):
@@ -45,7 +45,7 @@ class MCPToolsManagerBase(ABC):
         pass
 
 
-class SmolagentsMCPToolsManager(MCPToolsManagerBase):
+class SmolagentsMCPServerStdio(MCPServerBase):
     """Implementation of MCP tools manager for smolagents."""
 
     def __init__(self, mcp_tool: MCPTool):
@@ -113,7 +113,7 @@ class SmolagentsMCPToolsManager(MCPToolsManagerBase):
             del _smolagents_mcp_managers[self.id]
 
 
-class OpenAIMCPToolsManager(MCPToolsManagerBase):
+class OpenAIMCPServerStdio(MCPServerBase):
     """Implementation of MCP tools manager for OpenAI agents."""
 
     def __init__(self, mcp_tool: MCPTool):
@@ -124,9 +124,9 @@ class OpenAIMCPToolsManager(MCPToolsManagerBase):
 
     def setup_tools(self):
         """Set up the OpenAI MCP server with the provided configuration."""
-        from agents.mcp import MCPServerStdio
+        from agents.mcp import MCPServerStdio as OpenAIInternalMCPServerStdio
 
-        self.server = MCPServerStdio(
+        self.server = OpenAIInternalMCPServerStdio(
             name="OpenAI MCP Server",
             params={
                 "command": self.mcp_tool.command,
@@ -163,7 +163,7 @@ class OpenAIMCPToolsManager(MCPToolsManagerBase):
         self.cleanup()
 
 
-class LangchainMCPToolsManager(MCPToolsManagerBase):
+class LangchainMCPServerStdio(MCPServerBase):
     """Implementation of MCP tools manager for LangChain agents."""
 
     def __init__(self, mcp_tool: MCPTool):

--- a/src/any_agent/tools/wrappers.py
+++ b/src/any_agent/tools/wrappers.py
@@ -4,9 +4,9 @@ from collections.abc import Callable
 
 from any_agent.config import AgentFramework, MCPTool
 from any_agent.tools.mcp import (
-    SmolagentsMCPToolsManager,
-    OpenAIMCPToolsManager,
-    MCPToolsManagerBase,
+    SmolagentsMCPServerStdio,
+    OpenAIMCPServerStdio,
+    MCPServerBase,
 )
 
 
@@ -45,15 +45,15 @@ def wrap_tool_llama_index(tool):
 
 def wrap_mcp_server(
     mcp_tool: MCPTool, agent_framework: AgentFramework
-) -> MCPToolsManagerBase:
+) -> MCPServerBase:
     """
     Generic MCP server wrapper that can work with different frameworks
     based on the specified agent_framework
     """
     # Select the appropriate manager based on agent_framework
     manager_map = {
-        AgentFramework.OPENAI: OpenAIMCPToolsManager,
-        AgentFramework.SMOLAGENTS: SmolagentsMCPToolsManager,
+        AgentFramework.OPENAI: OpenAIMCPServerStdio,
+        AgentFramework.SMOLAGENTS: SmolagentsMCPServerStdio,
     }
 
     if agent_framework not in manager_map:
@@ -62,7 +62,7 @@ def wrap_mcp_server(
         )
 
     # Create the manager instance which will manage the MCP tool context
-    manager_class: MCPToolsManagerBase = manager_map[agent_framework]
+    manager_class: MCPServerBase = manager_map[agent_framework]
     manager = manager_class(mcp_tool)
 
     return manager
@@ -78,7 +78,7 @@ WRAPPERS = {
 
 def import_and_wrap_tools(
     tools: list[str | dict], agent_framework: AgentFramework
-) -> tuple[list[Callable], list[MCPToolsManagerBase]]:
+) -> tuple[list[Callable], list[MCPServerBase]]:
     wrapper = WRAPPERS[agent_framework]
 
     wrapped_tools = []
@@ -86,7 +86,7 @@ def import_and_wrap_tools(
     for tool in tools:
         if isinstance(tool, MCPTool):
             # MCP adapters are usually implemented as context managers.
-            # We wrap the server using `MCPToolsManagerBase` so the
+            # We wrap the server using `MCPServerBase` so the
             # tools can be used as any other callable.
             mcp_server = wrap_mcp_server(tool, agent_framework)
             mcp_servers.append(mcp_server)

--- a/tests/unit/tools/test_unit_mcp.py
+++ b/tests/unit/tools/test_unit_mcp.py
@@ -5,16 +5,16 @@ import unittest
 from unittest.mock import patch, MagicMock
 
 from any_agent.tools.mcp import (
-    MCPToolsManagerBase,
-    SmolagentsMCPToolsManager,
+    MCPServerBase,
+    SmolagentsMCPServerStdio,
 )
 
 
-class TestMCPToolsManagerBase(unittest.TestCase):
-    """Tests for the MCPToolsManagerBase class."""
+class TestMCPServerBase(unittest.TestCase):
+    """Tests for the MCPServerBase class."""
 
     # Define the test class once at class level instead of in each test method
-    class ConcreteMCPManager(MCPToolsManagerBase):
+    class ConcreteMCPManager(MCPServerBase):
         def setup_tools(self):
             pass
 
@@ -55,8 +55,8 @@ def create_specific_mock_tools():
 
 @patch("smolagents.ToolCollection")
 @patch("mcp.StdioServerParameters")
-class TestSmolagentsMCPToolsManager(unittest.TestCase):
-    """Tests for the SmolagentsMCPToolsManager class."""
+class TestSmolagentsMCPServerStdio(unittest.TestCase):
+    """Tests for the SmolagentsMCPServerStdio class."""
 
     def setUp(self):
         """Set up test fixtures before each test."""
@@ -76,8 +76,8 @@ class TestSmolagentsMCPToolsManager(unittest.TestCase):
         mock_tool_collection.from_mcp.return_value = self.mock_context
 
         # Initialize the manager with setup_tools patched
-        with patch.object(SmolagentsMCPToolsManager, "setup_tools", return_value=None):
-            manager = SmolagentsMCPToolsManager(self.test_tool)
+        with patch.object(SmolagentsMCPServerStdio, "setup_tools", return_value=None):
+            manager = SmolagentsMCPServerStdio(self.test_tool)
 
         # Set the context attribute
         manager.context = self.mock_context
@@ -104,7 +104,7 @@ class TestSmolagentsMCPToolsManager(unittest.TestCase):
         self.test_tool.tools = None
 
         # Initialize the manager
-        manager = SmolagentsMCPToolsManager(self.test_tool)
+        manager = SmolagentsMCPServerStdio(self.test_tool)
 
         # Verify all tools are included
         self.assertEqual(manager.tools, mock_tools)
@@ -125,7 +125,7 @@ class TestSmolagentsMCPToolsManager(unittest.TestCase):
         self.test_tool.tools = ["read_thing", "write_thing"]
 
         # Initialize the manager
-        manager = SmolagentsMCPToolsManager(self.test_tool)
+        manager = SmolagentsMCPServerStdio(self.test_tool)
 
         # Verify only the requested tools are included
         self.assertEqual(len(manager.tools), 2)


### PR DESCRIPTION
Use a simpler and framework agnostic name for MCPServers, and specify that current implementations are Stdio, we need to add in support for SSE