### PR TITLE
feat(llama_index): Use `LiteLLM` as default model class.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ langchain = [
 
 llama_index = [
   "llama-index",
+  "llama-index-llms-litellm",
   "platformdirs>=4.3.7",
   "openinference-instrumentation-llama-index"
 ]

--- a/src/any_agent/frameworks/llama_index.py
+++ b/src/any_agent/frameworks/llama_index.py
@@ -15,7 +15,7 @@ except ImportError:
     llama_index_available = False
 
 
-DEFAULT_MODEL_CLASS = "openai.OpenAI"
+DEFAULT_MODEL_CLASS = "litellm.LiteLLM"
 
 
 class LlamaIndexAgent(AnyAgent):

--- a/tests/unit/frameworks/test_llama_index.py
+++ b/tests/unit/frameworks/test_llama_index.py
@@ -19,11 +19,13 @@ def test_load_llama_index_agent_default():
 
     with (
         patch("any_agent.frameworks.llama_index.ReActAgent", create_mock),
-        patch("llama_index.llms.openai.OpenAI", model_mock),
+        patch("llama_index.llms.litellm.LiteLLM", model_mock),
         patch.object(FunctionTool, "from_defaults", tool_mock),
     ):
-        AnyAgent.create(AgentFramework.LLAMAINDEX, AgentConfig(model_id="gpt-4o"))
-        model_mock.assert_called_once_with(model="gpt-4o")
+        AnyAgent.create(
+            AgentFramework.LLAMAINDEX, AgentConfig(model_id="gemini/gemini-2.0-flash")
+        )
+        model_mock.assert_called_once_with(model="gemini/gemini-2.0-flash")
         create_mock.assert_called_once_with(
             name="any_agent",
             llm=model_mock.return_value,


### PR DESCRIPTION
Helps standardizing the default `model_id` behavior.