### PR TITLE
feat: Add support for Google Agent Development Kit (ADK)

### DIFF
--- a/docs/frameworks.md
+++ b/docs/frameworks.md
@@ -9,6 +9,21 @@ Here you can find the frameworks currently supported in `any-agent`, along with 
 
     If there is no existing issue, don't hesitate to request and/or contribute it.
 
+
+=== "Google ADK"
+
+    [Google ADK Repo](https://github.com/google/adk-python)
+
+    ``` py
+    agent = AnyAgent.create(
+        framework=AgentFramework("google"),
+        main_agent=AgentConfig(
+            model_id="gpt-4o-mini"
+        )
+    )
+    agent.run("Which Agent Framework is the best??")
+    ```
+
 === "🦜🔗 LangChain"
 
     [LangChain Repo](https://github.com/langchain-ai/langchain)
@@ -37,7 +52,7 @@ Here you can find the frameworks currently supported in `any-agent`, along with 
     agent.run("Which Agent Framework is the best??")
     ```
 
-=== "OpenAI Agents"
+=== "OpenAI Agents SDK"
 
     [OpenAI Agents Repo](https://github.com/openai/openai-agents-python)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+google = [
+  "google-adk"
+]
+
 langchain = [
   "langchain",
   "langchain-openai>=0.3.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ mcp = [
 ]
 
 all = [
-  "any-agent[langchain,llama_index,smolagents,openai,mcp]"
+  "any-agent[google,langchain,llama_index,smolagents,openai,mcp]"
 ]
 
 docs = [

--- a/src/any_agent/config.py
+++ b/src/any_agent/config.py
@@ -3,10 +3,11 @@ from pydantic import BaseModel, Field, ConfigDict
 
 
 class AgentFramework(str, Enum):
-    OPENAI = "openai"
+    GOOGLE = "google"
     LANGCHAIN = "langchain"
-    SMOLAGENTS = "smolagents"
     LLAMAINDEX = "llama_index"
+    OPENAI = "openai"
+    SMOLAGENTS = "smolagents"
 
 
 class MCPTool(BaseModel):

--- a/src/any_agent/frameworks/__init__.py
+++ b/src/any_agent/frameworks/__init__.py
@@ -1,4 +1,5 @@
 from .any_agent import AnyAgent
+from .google import GoogleAgent
 from .langchain import LangchainAgent
 from .llama_index import LlamaIndexAgent
 from .openai import OpenAIAgent
@@ -7,6 +8,7 @@ from .smolagents import SmolagentsAgent
 
 __all__ = [
     "AnyAgent",
+    "GoogleAgent",
     "LangchainAgent",
     "LlamaIndexAgent",
     "OpenAIAgent",

--- a/src/any_agent/frameworks/any_agent.py
+++ b/src/any_agent/frameworks/any_agent.py
@@ -34,6 +34,10 @@ class AnyAgent(ABC):
             from any_agent.frameworks.llama_index import LlamaIndexAgent
 
             return LlamaIndexAgent(agent_config, managed_agents=managed_agents)
+        elif agent_framework == AgentFramework.GOOGLE:
+            from any_agent.frameworks.google import GoogleAgent
+
+            return GoogleAgent(agent_config, managed_agents=managed_agents)
         else:
             raise ValueError(f"Unsupported agent framework: {agent_framework}")
 

--- a/src/any_agent/frameworks/google.py
+++ b/src/any_agent/frameworks/google.py
@@ -1,0 +1,121 @@
+from typing import Optional, Any, List
+from uuid import uuid4
+
+from loguru import logger
+
+from any_agent.config import AgentFramework, AgentConfig
+from any_agent.instructions import get_instructions
+from any_agent.tools.wrappers import import_and_wrap_tools
+from .any_agent import AnyAgent
+
+try:
+    from google.adk.agents import Agent
+    from google.adk.models.lite_llm import LiteLlm
+    from google.adk.runners import InMemoryRunner
+    from google.adk.tools.agent_tool import AgentTool
+    from google.genai import types
+
+    adk_available = True
+except ImportError:
+    adk_available = None
+
+OPENAI_MAX_TURNS = 30
+
+
+class GoogleAgent(AnyAgent):
+    """Google agent implementation that handles both loading and running."""
+
+    def __init__(
+        self, config: AgentConfig, managed_agents: Optional[list[AgentConfig]] = None
+    ):
+        self.managed_agents = managed_agents
+        self.config = config
+        self._agent = None
+        self._load_agent()
+
+    def _get_model(self, agent_config: AgentConfig):
+        """Get the model configuration for a Google agent."""
+        return LiteLlm(model=agent_config.model_id, **agent_config.model_args or {})
+
+    @logger.catch(reraise=True)
+    def _load_agent(self) -> None:
+        """Load the Google agent with the given configuration."""
+        if not adk_available:
+            raise ImportError("You need to `pip install google-adk` to use this agent")
+
+        if not self.managed_agents and not self.config.tools:
+            self.config.tools = [
+                "any_agent.tools.search_web",
+                "any_agent.tools.visit_webpage",
+            ]
+        tools, mcp_servers = import_and_wrap_tools(
+            self.config.tools, agent_framework=AgentFramework.GOOGLE
+        )
+
+        sub_agents_instanced = []
+        if self.managed_agents:
+            for managed_agent in self.managed_agents:
+                managed_tools, managed_mcp_servers = import_and_wrap_tools(
+                    managed_agent.tools, agent_framework=AgentFramework.GOOGLE
+                )
+                instance = Agent(
+                    name=managed_agent.name,
+                    instruction=get_instructions(managed_agent.instructions) or "",
+                    model=self._get_model(managed_agent),
+                    tools=managed_tools,
+                    **managed_agent.agent_args or {},
+                )
+
+                if managed_agent.handoff:
+                    sub_agents_instanced.append(instance)
+                else:
+                    tools.append(AgentTool(instance))
+
+        self._agent = Agent(
+            name=self.config.name,
+            instruction=self.config.instructions or "",
+            model=self._get_model(self.config),
+            tools=tools,
+            sub_agents=sub_agents_instanced,
+            **self.config.agent_args or {},
+            output_key="response",
+        )
+
+    @logger.catch(reraise=True)
+    def run(
+        self, prompt: str, user_id: str | None = None, session_id: str | None = None
+    ) -> Any:
+        """Run the Google agent with the given prompt."""
+        if not adk_available:
+            raise ImportError("You need to `pip install google-adk` to use this agent")
+        runner = InMemoryRunner(self._agent)
+        user_id = user_id or str(uuid4())
+        session_id = session_id or str(uuid4())
+        runner.session_service.create_session(
+            app_name=runner.app_name, user_id=user_id, session_id=session_id
+        )
+        for event in runner.run(
+            user_id=user_id,
+            session_id=session_id,
+            new_message=types.Content(role="user", parts=[types.Part(text=prompt)]),
+        ):
+            logger.debug(event)
+            if event.is_final_response():
+                break
+        session = runner.session_service.get_session(
+            app_name=runner.app_name, user_id=user_id, session_id=session_id
+        )
+        return session.state.get("response", None)
+
+    @property
+    def tools(self) -> List[str]:
+        """
+        Return the tools used by the agent.
+        This property is read-only and cannot be modified.
+        """
+        if hasattr(self, "_agent"):
+            tools = [tool.name for tool in self._agent.tools]
+        else:
+            logger.warning("Agent not loaded or does not have tools.")
+            tools = []
+        return tools

--- a/src/any_agent/tools/wrappers.py
+++ b/src/any_agent/tools/wrappers.py
@@ -43,6 +43,14 @@ def wrap_tool_llama_index(tool):
     return tool
 
 
+def wrap_tool_google(tool):
+    from google.adk.tools import BaseTool, FunctionTool
+
+    if not isinstance(tool, BaseTool):
+        return FunctionTool(tool)
+    return tool
+
+
 def wrap_mcp_server(
     mcp_tool: MCPTool, agent_framework: AgentFramework
 ) -> MCPServerBase:
@@ -69,6 +77,7 @@ def wrap_mcp_server(
 
 
 WRAPPERS = {
+    AgentFramework.GOOGLE: wrap_tool_google,
     AgentFramework.OPENAI: wrap_tool_openai,
     AgentFramework.LANGCHAIN: wrap_tool_langchain,
     AgentFramework.SMOLAGENTS: wrap_tool_smolagents,

--- a/tests/integration/test_load_and_run_agent.py
+++ b/tests/integration/test_load_and_run_agent.py
@@ -6,7 +6,7 @@ from any_agent import AgentFramework, AgentConfig, AnyAgent
 
 
 @pytest.mark.parametrize(
-    "framework", ("langchain", "openai", "smolagents", "llama_index")
+    "framework", ("google", "langchain", "openai", "smolagents", "llama_index")
 )
 @pytest.mark.skipif(
     "OPENAI_API_KEY" not in os.environ,

--- a/tests/integration/test_load_and_run_multi_agent.py
+++ b/tests/integration/test_load_and_run_multi_agent.py
@@ -5,7 +5,7 @@ import pytest
 from any_agent import AgentFramework, AgentConfig, AnyAgent
 
 
-@pytest.mark.parametrize("framework", ("openai", "smolagents"))
+@pytest.mark.parametrize("framework", ("google", "openai", "smolagents"))
 @pytest.mark.skipif(
     "OPENAI_API_KEY" not in os.environ,
     reason="Integration tests require `OPENAI_API_KEY` env var",
@@ -16,7 +16,7 @@ def test_load_and_run_multi_agent(framework):
     if framework == "smolagents":
         kwargs["agent_type"] = "ToolCallingAgent"
     main_agent = AgentConfig(
-        model_id="gpt-4o-mini",
+        model_id="gpt-4o",
         instructions="Use the available agents to complete the task.",
         **kwargs,
     )
@@ -34,6 +34,16 @@ def test_load_and_run_multi_agent(framework):
             tools=["any_agent.tools.visit_webpage"],
         ),
     ]
+    if framework != "smolagents":
+        managed_agents.append(
+            AgentConfig(
+                name="final_answer_agent",
+                model_id="gpt-4o-mini",
+                description="Agent that can show the final answer",
+                tools=["any_agent.tools.show_final_answer"],
+                handoff=True,
+            ),
+        )
     agent = AnyAgent.create(
         agent_framework=agent_framework,
         agent_config=main_agent,

--- a/tests/unit/frameworks/test_google.py
+++ b/tests/unit/frameworks/test_google.py
@@ -27,7 +27,7 @@ def test_load_google_default():
         AnyAgent.create(AgentFramework.GOOGLE, AgentConfig(model_id="gpt-4o"))
         mock_agent.assert_called_once_with(
             name="any_agent",
-            instruction=None,
+            instruction="",
             model=mock_model(model="gpt-4o"),
             tools=[MockedFunctionTool(search_web), MockedFunctionTool(visit_webpage)],
             sub_agents=[],
@@ -75,19 +75,19 @@ def test_load_google_multiagent():
         )
         mock_agent.assert_any_call(
             model=mock_model(model="gpt-4o-mini"),
-            instruction=None,
+            instruction="",
             name="search-web-agent",
             tools=[MockedFunctionTool(search_web), MockedFunctionTool(visit_webpage)],
         )
         mock_agent.assert_any_call(
             model=mock_model(model="gpt-4o-mini"),
-            instruction=None,
+            instruction="",
             name="communication-agent",
             tools=[MockedFunctionTool(show_final_answer)],
         )
         mock_agent.assert_any_call(
             name="any_agent",
-            instruction=None,
+            instruction="",
             model=mock_model(model="gpt-4o"),
             tools=[mock_agent_tool.return_value],
             sub_agents=[mock_agent.return_value],

--- a/tests/unit/frameworks/test_google.py
+++ b/tests/unit/frameworks/test_google.py
@@ -1,0 +1,95 @@
+from unittest.mock import patch, MagicMock
+
+from any_agent import AgentFramework, AgentConfig, AnyAgent
+from any_agent.tools import (
+    search_web,
+    show_final_answer,
+    visit_webpage,
+)
+
+
+def test_load_google_default():
+    from google.adk.tools import FunctionTool
+
+    mock_agent = MagicMock()
+    mock_model = MagicMock()
+    mock_function_tool = MagicMock()
+
+    class MockedFunctionTool(FunctionTool):
+        def __new__(cls, *args, **kwargs):
+            return mock_function_tool
+
+    with (
+        patch("any_agent.frameworks.google.Agent", mock_agent),
+        patch("any_agent.frameworks.google.LiteLlm", mock_model),
+        patch("google.adk.tools.FunctionTool", MockedFunctionTool),
+    ):
+        AnyAgent.create(AgentFramework.GOOGLE, AgentConfig(model_id="gpt-4o"))
+        mock_agent.assert_called_once_with(
+            name="any_agent",
+            instruction=None,
+            model=mock_model(model="gpt-4o"),
+            tools=[MockedFunctionTool(search_web), MockedFunctionTool(visit_webpage)],
+            sub_agents=[],
+            output_key="response",
+        )
+
+
+def test_load_google_multiagent():
+    from google.adk.tools import FunctionTool
+
+    mock_agent = MagicMock()
+    mock_model = MagicMock()
+    mock_agent_tool = MagicMock()
+    mock_function_tool = MagicMock()
+
+    class MockedFunctionTool(FunctionTool):
+        def __new__(cls, *args, **kwargs):
+            return mock_function_tool
+
+    with (
+        patch("any_agent.frameworks.google.Agent", mock_agent),
+        patch("any_agent.frameworks.google.LiteLlm", mock_model),
+        patch("any_agent.frameworks.google.AgentTool", mock_agent_tool),
+        patch("google.adk.tools.FunctionTool", MockedFunctionTool),
+    ):
+        AnyAgent.create(
+            AgentFramework.GOOGLE,
+            AgentConfig(model_id="gpt-4o"),
+            managed_agents=[
+                AgentConfig(
+                    model_id="gpt-4o-mini",
+                    name="search-web-agent",
+                    tools=[
+                        "any_agent.tools.search_web",
+                        "any_agent.tools.visit_webpage",
+                    ],
+                ),
+                AgentConfig(
+                    model_id="gpt-4o-mini",
+                    name="communication-agent",
+                    tools=["any_agent.tools.show_final_answer"],
+                    handoff=True,
+                ),
+            ],
+        )
+        mock_agent.assert_any_call(
+            model=mock_model(model="gpt-4o-mini"),
+            instruction=None,
+            name="search-web-agent",
+            tools=[MockedFunctionTool(search_web), MockedFunctionTool(visit_webpage)],
+        )
+        mock_agent.assert_any_call(
+            model=mock_model(model="gpt-4o-mini"),
+            instruction=None,
+            name="communication-agent",
+            tools=[MockedFunctionTool(show_final_answer)],
+        )
+        mock_agent.assert_any_call(
+            name="any_agent",
+            instruction=None,
+            model=mock_model(model="gpt-4o"),
+            tools=[mock_agent_tool.return_value],
+            sub_agents=[mock_agent.return_value],
+            output_key="response",
+        )

--- a/tests/unit/tools/test_unit_wrappers.py
+++ b/tests/unit/tools/test_unit_wrappers.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 from any_agent.tools.wrappers import (
+    wrap_tool_google,
     wrap_tool_langchain,
     wrap_tool_llama_index,
     wrap_tool_openai,
@@ -16,8 +17,8 @@ def foo() -> None:
 def test_wrap_tool_langchain():
     wrapper = MagicMock()
     with patch("langchain_core.tools.tool", wrapper):
-        wrap_tool_langchain("any_agent.tools.search_web")
-        wrapper.assert_called_with("any_agent.tools.search_web")
+        wrap_tool_langchain(foo)
+        wrapper.assert_called_with(foo)
 
 
 def test_wrap_tool_langchain_already_wrapped():
@@ -35,8 +36,8 @@ def test_wrap_tool_llama_index():
 
     wrapper = MagicMock()
     with patch.object(FunctionTool, "from_defaults", wrapper):
-        wrap_tool_llama_index("any_agent.tools.search_web")
-        wrapper.assert_called_with("any_agent.tools.search_web")
+        wrap_tool_llama_index(foo)
+        wrapper.assert_called_with(foo)
 
 
 def test_wrap_tool_llama_index_already_wrapped():
@@ -52,8 +53,8 @@ def test_wrap_tool_llama_index_already_wrapped():
 def test_wrap_tool_openai():
     wrapper = MagicMock()
     with patch("agents.function_tool", wrapper):
-        wrap_tool_openai("any_agent.tools.search_web")
-        wrapper.assert_called_with("any_agent.tools.search_web")
+        wrap_tool_openai(foo)
+        wrapper.assert_called_with(foo)
 
 
 def test_wrap_tool_openai_already_wrapped():
@@ -78,8 +79,8 @@ def test_wrap_tool_openai_builtin_tools():
 def test_wrap_tool_smolagents():
     wrapper = MagicMock()
     with patch("smolagents.tool", wrapper):
-        wrap_tool_smolagents("any_agent.tools.search_web")
-        wrapper.assert_called_with("any_agent.tools.search_web")
+        wrap_tool_smolagents(foo)
+        wrapper.assert_called_with(foo)
 
 
 def test_wrap_tool_smolagents_already_wrapped():
@@ -98,4 +99,38 @@ def test_wrap_tool_smolagents_builtin_tools():
     wrapper = MagicMock()
     with patch("smolagents.tool", wrapper):
         wrap_tool_smolagents(DuckDuckGoSearchTool())
+        wrapper.assert_not_called()
+
+
+def test_wrap_tool_google():
+    from google.adk.tools import FunctionTool
+
+    wrapper = MagicMock()
+    wrapper.return_value = None
+
+    with patch.object(FunctionTool, "__init__", wrapper):
+        wrap_tool_google(foo)
+        wrapper.assert_called_with(foo)
+
+
+def test_wrap_tool_google_already_wrapped():
+    from google.adk.tools import FunctionTool
+
+    wrapper = MagicMock()
+    wrapper.return_value = None
+    wrapped = FunctionTool(foo)
+
+    with patch.object(FunctionTool, "__init__", wrapper):
+        wrap_tool_google(wrapped)
+        wrapper.assert_not_called()
+
+
+def test_wrap_tool_google_builtin_tools():
+    from google.adk.tools import FunctionTool, google_search
+
+    wrapper = MagicMock()
+    wrapper.return_value = None
+
+    with patch.object(FunctionTool, "__init__", wrapper):
+        wrap_tool_google(google_search)
         wrapper.assert_not_called()


### PR DESCRIPTION
- Use `LiteLlm` as default model class.
- Implement managed_agents using "AgentTool" and `sub_agents` (when handoff=True).