### PR TITLE
Improvements to integration tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -34,4 +34,7 @@ jobs:
         run: pytest -v tests/unit
 
       - name: Run Integration tests
+        env:
+          ANY_AGENT_INTEGRATION_TESTS: TRUE
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: pytest -v tests/integration

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,4 +37,4 @@ jobs:
         env:
           ANY_AGENT_INTEGRATION_TESTS: TRUE
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-        run: pytest -v tests/integration
+        run: pytest -v tests/integration -s

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,4 +37,4 @@ jobs:
         env:
           ANY_AGENT_INTEGRATION_TESTS: TRUE
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-        run: pytest -v tests/integration -s
+        run: pytest -v tests/integration

--- a/src/any_agent/frameworks/google.py
+++ b/src/any_agent/frameworks/google.py
@@ -33,6 +33,7 @@ class GoogleAgent(AnyAgent):
         self.managed_agents = managed_agents
         self.config = config
         self._agent = None
+        self._agent_loaded = False
 
     def _get_model(self, agent_config: AgentConfig):
         """Get the model configuration for a Google agent."""

--- a/src/any_agent/frameworks/langchain.py
+++ b/src/any_agent/frameworks/langchain.py
@@ -32,6 +32,7 @@ class LangchainAgent(AnyAgent):
         self.managed_agents = managed_agents
         self.config = config
         self._agent = None
+        self._agent_loaded = False
         self._tools = []
 
     def _get_model(self, agent_config: AgentConfig):

--- a/src/any_agent/frameworks/llama_index.py
+++ b/src/any_agent/frameworks/llama_index.py
@@ -31,6 +31,7 @@ class LlamaIndexAgent(AnyAgent):
         self.managed_agents: Optional[list[AgentConfig]] = managed_agents
         self.config: AgentConfig = config
         self._agent = None
+        self._agent_loaded = False
 
     def _get_model(self, agent_config: AgentConfig):
         """Get the model configuration for a llama_index agent."""

--- a/src/any_agent/frameworks/openai.py
+++ b/src/any_agent/frameworks/openai.py
@@ -31,6 +31,7 @@ class OpenAIAgent(AnyAgent):
         self.managed_agents = managed_agents
         self.config = config
         self._agent = None
+        self._agent_loaded = False
 
     def _get_model(self, agent_config: AgentConfig):
         """Get the model configuration for an OpenAI agent."""

--- a/src/any_agent/frameworks/smolagents.py
+++ b/src/any_agent/frameworks/smolagents.py
@@ -32,6 +32,7 @@ class SmolagentsAgent(AnyAgent):
         self.managed_agents = managed_agents
         self.config = config
         self._agent = None
+        self._agent_loaded = False
 
     def _get_model(self, agent_config: AgentConfig):
         """Get the model configuration for a smolagents agent."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+import sys
+
+import pytest
+
+
+@pytest.fixture(scope="function")
+def refresh_tools():
+    """
+    smolagents tool wrapping hacks the original function signature
+    of the tool that you pass.
+    That causes that a tool already wrapped in the same python
+    process will fail the second time you try to wrap it.
+    This is the simplest way I found to invalidate the modified
+    signature.
+    """
+    tool_modules = []
+    for k in sys.modules.keys():
+        if "any_agent.tools" in k:
+            tool_modules.append(k)
+    for module in tool_modules:
+        del sys.modules[module]

--- a/tests/integration/test_load_and_run_agent.py
+++ b/tests/integration/test_load_and_run_agent.py
@@ -3,22 +3,36 @@ import os
 import pytest
 
 from any_agent import AgentFramework, AgentConfig, AnyAgent
+from any_agent.tracing import setup_tracing
 
 frameworks = [item for item in AgentFramework]
 
 
 @pytest.mark.parametrize("framework", frameworks)
 @pytest.mark.skipif(
-    "OPENAI_API_KEY" not in os.environ,
-    reason="Integration tests require `OPENAI_API_KEY` env var",
+    os.environ.get("ANY_AGENT_INTEGRATION_TESTS", "FALSE").upper() != "TRUE",
+    reason="Integration tests require `ANY_AGENT_INTEGRATION_TESTS=TRUE` env var",
 )
-def test_load_and_run_agent(framework):
+def test_load_and_run_agent(framework, tmp_path):
     agent_framework = AgentFramework(framework)
     kwargs = {}
+
     if framework == "smolagents":
         kwargs["agent_type"] = "ToolCallingAgent"
+
+    if framework != "openai":
+        kwargs["model_id"] = "gemini/gemini-2.0-flash"
+        if "GEMINI_API_KEY" not in os.environ:
+            pytest.skip(f"GEMINI_API_KEY needed for {framework}")
+    else:
+        kwargs["model_id"] = "gpt-4o-mini"
+        if "OPENAI_API_KEY" not in os.environ:
+            pytest.skip(f"OPENAI_API_KEY needed for {framework}")
+
+    if framework != "google":
+        setup_tracing(agent_framework, str(tmp_path / "traces"))
+
     agent_config = AgentConfig(
-        model_id="gpt-4o-mini",
         tools=["any_agent.tools.search_web"],
         instructions="Search the web to answer",
         **kwargs,

--- a/tests/integration/test_load_and_run_agent.py
+++ b/tests/integration/test_load_and_run_agent.py
@@ -38,6 +38,6 @@ def test_load_and_run_agent(framework, tmp_path, refresh_tools):
         **kwargs,
     )
     agent = AnyAgent.create(agent_framework, agent_config)
-    assert len(agent.tools) > 0
     result = agent.run("Which agent framework is the best?")
+    assert len(agent.tools) > 0
     assert result

--- a/tests/integration/test_load_and_run_agent.py
+++ b/tests/integration/test_load_and_run_agent.py
@@ -13,7 +13,7 @@ frameworks = [item for item in AgentFramework]
     os.environ.get("ANY_AGENT_INTEGRATION_TESTS", "FALSE").upper() != "TRUE",
     reason="Integration tests require `ANY_AGENT_INTEGRATION_TESTS=TRUE` env var",
 )
-def test_load_and_run_agent(framework, tmp_path):
+def test_load_and_run_agent(framework, tmp_path, refresh_tools):
     agent_framework = AgentFramework(framework)
     kwargs = {}
 

--- a/tests/integration/test_load_and_run_multi_agent.py
+++ b/tests/integration/test_load_and_run_multi_agent.py
@@ -11,7 +11,7 @@ from any_agent.tracing import setup_tracing
     os.environ.get("ANY_AGENT_INTEGRATION_TESTS", "FALSE").upper() != "TRUE",
     reason="Integration tests require `ANY_AGENT_INTEGRATION_TESTS=TRUE` env var",
 )
-def test_load_and_run_multi_agent(framework, tmp_path):
+def test_load_and_run_multi_agent(framework, tmp_path, refresh_tools):
     agent_framework = AgentFramework(framework)
     kwargs = {}
     if framework == "smolagents":

--- a/tests/integration/test_load_and_run_multi_agent.py
+++ b/tests/integration/test_load_and_run_multi_agent.py
@@ -3,33 +3,46 @@ import os
 import pytest
 
 from any_agent import AgentFramework, AgentConfig, AnyAgent
+from any_agent.tracing import setup_tracing
 
 
 @pytest.mark.parametrize("framework", ("google", "openai", "smolagents"))
 @pytest.mark.skipif(
-    "OPENAI_API_KEY" not in os.environ,
-    reason="Integration tests require `OPENAI_API_KEY` env var",
+    os.environ.get("ANY_AGENT_INTEGRATION_TESTS", "FALSE").upper() != "TRUE",
+    reason="Integration tests require `ANY_AGENT_INTEGRATION_TESTS=TRUE` env var",
 )
-def test_load_and_run_multi_agent(framework):
+def test_load_and_run_multi_agent(framework, tmp_path):
     agent_framework = AgentFramework(framework)
     kwargs = {}
     if framework == "smolagents":
         kwargs["agent_type"] = "ToolCallingAgent"
+
+    if framework != "openai":
+        kwargs["model_id"] = "gemini/gemini-2.0-flash"
+        if "GEMINI_API_KEY" not in os.environ:
+            pytest.skip(f"GEMINI_API_KEY needed for {framework}")
+    else:
+        kwargs["model_id"] = "gpt-4o-mini"
+        if "OPENAI_API_KEY" not in os.environ:
+            pytest.skip(f"OPENAI_API_KEY needed for {framework}")
+
+    if framework != "google":
+        setup_tracing(agent_framework, str(tmp_path / "traces"))
+
     main_agent = AgentConfig(
-        model_id="gpt-4o",
         instructions="Use the available agents to complete the task.",
         **kwargs,
     )
     managed_agents = [
         AgentConfig(
             name="search_web_agent",
-            model_id="gpt-4o-mini",
+            model_id=kwargs["model_id"],
             description="Agent that can search the web",
             tools=["any_agent.tools.search_web"],
         ),
         AgentConfig(
             name="visit_webpage_agent",
-            model_id="gpt-4o-mini",
+            model_id=kwargs["model_id"],
             description="Agent that can visit webpages",
             tools=["any_agent.tools.visit_webpage"],
         ),
@@ -38,7 +51,7 @@ def test_load_and_run_multi_agent(framework):
         managed_agents.append(
             AgentConfig(
                 name="final_answer_agent",
-                model_id="gpt-4o-mini",
+                model_id=kwargs["model_id"],
                 description="Agent that can show the final answer",
                 tools=["any_agent.tools.show_final_answer"],
                 handoff=True,

--- a/tests/integration/test_mcp.py
+++ b/tests/integration/test_mcp.py
@@ -15,8 +15,8 @@ frameworks = [
     frameworks,
 )
 @pytest.mark.skipif(
-    "OPENAI_API_KEY" not in os.environ,
-    reason="Integration tests require `OPENAI_API_KEY` env var",
+    os.environ.get("MCP_INTEGRATION_TESTS", "FALSE").upper() != "TRUE",
+    reason="Integration tests require `MCP_INTEGRATION_TESTS=TRUE` env var",
 )
 def test_mcp(framework):
     agent_framework = AgentFramework(framework)


### PR DESCRIPTION
- Use `gemini/gemini-2.0-flash` via LiteLLM for frameworks that support it.
- Add `setup_tracing` for frameworks that support it.
- Use `ANY_AGENT_INTEGRATION_TESTS` env var. Closes https://github.com/mozilla-ai/any-agent/issues/34
- Run integration tests in Github Actions workflow