### PR TITLE
Make Agent.run use async under the hood

### DIFF
--- a/src/any_agent/frameworks/any_agent.py
+++ b/src/any_agent/frameworks/any_agent.py
@@ -48,10 +48,10 @@ class AnyAgent(ABC):
 
     def run(self, prompt: str) -> Any:
         """Run the agent with the given prompt."""
-        return asyncio.get_event_loop().run_until_complete(self._async_run(prompt))
+        return asyncio.get_event_loop().run_until_complete(self.run_async(prompt))
 
     @abstractmethod
-    async def _async_run(self, prompt: str) -> Any:
+    async def run_async(self, prompt: str) -> Any:
         """Run the agent asynchronously with the given prompt."""
         pass
 

--- a/src/any_agent/frameworks/any_agent.py
+++ b/src/any_agent/frameworks/any_agent.py
@@ -1,6 +1,6 @@
 from typing import Any, Optional, List
 from abc import ABC, abstractmethod
-
+import asyncio
 from any_agent.config import AgentFramework, AgentConfig
 
 
@@ -46,9 +46,13 @@ class AnyAgent(ABC):
         """Load the agent instance."""
         pass
 
-    @abstractmethod
     def run(self, prompt: str) -> Any:
         """Run the agent with the given prompt."""
+        return asyncio.get_event_loop().run_until_complete(self._async_run(prompt))
+
+    @abstractmethod
+    async def _async_run(self, prompt: str) -> Any:
+        """Run the agent asynchronously with the given prompt."""
         pass
 
     @property

--- a/src/any_agent/frameworks/google.py
+++ b/src/any_agent/frameworks/google.py
@@ -81,7 +81,7 @@ class GoogleAgent(AnyAgent):
         )
 
     @logger.catch(reraise=True)
-    def run(
+    async def _async_run(
         self, prompt: str, user_id: str | None = None, session_id: str | None = None
     ) -> Any:
         """Run the Google agent with the given prompt."""

--- a/src/any_agent/frameworks/google.py
+++ b/src/any_agent/frameworks/google.py
@@ -81,7 +81,7 @@ class GoogleAgent(AnyAgent):
         )
 
     @logger.catch(reraise=True)
-    async def _async_run(
+    async def run_async(
         self, prompt: str, user_id: str | None = None, session_id: str | None = None
     ) -> Any:
         """Run the Google agent with the given prompt."""

--- a/src/any_agent/frameworks/langchain.py
+++ b/src/any_agent/frameworks/langchain.py
@@ -77,7 +77,7 @@ class LangchainAgent(AnyAgent):
         self._tools = imported_tools
 
     @logger.catch(reraise=True)
-    async def _async_run(self, prompt: str) -> Any:
+    async def run_async(self, prompt: str) -> Any:
         """Run the LangChain agent with the given prompt."""
         inputs = {"messages": [("user", prompt)]}
         message = None

--- a/src/any_agent/frameworks/langchain.py
+++ b/src/any_agent/frameworks/langchain.py
@@ -77,7 +77,7 @@ class LangchainAgent(AnyAgent):
         self._tools = imported_tools
 
     @logger.catch(reraise=True)
-    def run(self, prompt: str) -> Any:
+    async def _async_run(self, prompt: str) -> Any:
         """Run the LangChain agent with the given prompt."""
         inputs = {"messages": [("user", prompt)]}
         message = None

--- a/src/any_agent/frameworks/llama_index.py
+++ b/src/any_agent/frameworks/llama_index.py
@@ -1,5 +1,5 @@
 import importlib
-from typing import Any, Optional, List
+from typing import Optional, List
 
 from loguru import logger
 
@@ -74,16 +74,10 @@ class LlamaIndexAgent(AnyAgent):
             **self.config.agent_args or {},
         )
 
+    @logger.catch(reraise=True)
     async def _async_run(self, prompt):
         result = await self._agent.run(prompt)
         return result
-
-    @logger.catch(reraise=True)
-    def run(self, prompt: str) -> Any:
-        """Run the LlamaIndex agent with the given prompt."""
-        import asyncio
-
-        return asyncio.run(self._async_run(prompt))
 
     @property
     def tools(self) -> List[str]:

--- a/src/any_agent/frameworks/llama_index.py
+++ b/src/any_agent/frameworks/llama_index.py
@@ -75,7 +75,7 @@ class LlamaIndexAgent(AnyAgent):
         )
 
     @logger.catch(reraise=True)
-    async def _async_run(self, prompt):
+    async def run_async(self, prompt):
         result = await self._agent.run(prompt)
         return result
 

--- a/src/any_agent/frameworks/openai.py
+++ b/src/any_agent/frameworks/openai.py
@@ -111,10 +111,9 @@ class OpenAIAgent(AnyAgent):
         )
 
     @logger.catch(reraise=True)
-    def run(self, prompt: str) -> Any:
-        """Run the OpenAI agent with the given prompt."""
-
-        result = Runner.run_sync(self._agent, prompt, max_turns=OPENAI_MAX_TURNS)
+    async def _async_run(self, prompt: str) -> Any:
+        """Run the OpenAI agent with the given prompt asynchronously."""
+        result = await Runner.run(self._agent, prompt, max_turns=OPENAI_MAX_TURNS)
         return result
 
     @property

--- a/src/any_agent/frameworks/openai.py
+++ b/src/any_agent/frameworks/openai.py
@@ -111,7 +111,7 @@ class OpenAIAgent(AnyAgent):
         )
 
     @logger.catch(reraise=True)
-    async def _async_run(self, prompt: str) -> Any:
+    async def run_async(self, prompt: str) -> Any:
         """Run the OpenAI agent with the given prompt asynchronously."""
         result = await Runner.run(self._agent, prompt, max_turns=OPENAI_MAX_TURNS)
         return result

--- a/src/any_agent/frameworks/smolagents.py
+++ b/src/any_agent/frameworks/smolagents.py
@@ -108,7 +108,7 @@ class SmolagentsAgent(AnyAgent):
             self._agent.prompt_templates["system_prompt"] = self.config.instructions
 
     @logger.catch(reraise=True)
-    def run(self, prompt: str) -> Any:
+    async def _async_run(self, prompt: str) -> Any:
         """Run the Smolagents agent with the given prompt."""
         result = self._agent.run(prompt)
         return result

--- a/src/any_agent/frameworks/smolagents.py
+++ b/src/any_agent/frameworks/smolagents.py
@@ -108,7 +108,7 @@ class SmolagentsAgent(AnyAgent):
             self._agent.prompt_templates["system_prompt"] = self.config.instructions
 
     @logger.catch(reraise=True)
-    async def _async_run(self, prompt: str) -> Any:
+    async def run_async(self, prompt: str) -> Any:
         """Run the Smolagents agent with the given prompt."""
         result = self._agent.run(prompt)
         return result


### PR DESCRIPTION
In prod use cases, async appears to be the popular choice. So, lets begin building for the async world. Each agent implementation uses async, but there is an entry `sync` option in the any-agent class that calls asyncio.run to keep sync an option. 