### PR TITLE
Tracing as a setting when creating the Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,10 @@ pip install 'any-agent[all]'
 To define any agent system you will always use the same imports:
 
 ```py
-from any_agent import AgentConfig, AgentFramework, AnyAgent
-from any_agent.tracing import setup_tracing  # Optional, but recommended
+from any_agent import AgentConfig, AgentFramework, AnyAgent, TracingConfig
 
 # See all options in https://mozilla-ai.github.io/any-agent/frameworks/
 framework = AgentFramework("smolagents")
-
-setup_tracing(framework)
 ```
 
 ### Single agent
@@ -60,6 +57,7 @@ agent = AnyAgent.create(
         instructions="Use the tools to find an answer",
         tools=[search_web, visit_webpage]
     )
+    TracingConfig(output_dir="output") # Optional, but recommended for saving and viewing traces
 )
 
 agent.run("Which Agent Framework is the best??")

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ agent = AnyAgent.create(
         instructions="Use the tools to find an answer",
         tools=[search_web, visit_webpage]
     )
-    TracingConfig(output_dir="output") # Optional, but recommended for saving and viewing traces
+    TracingConfig(output_dir="traces") # Optional, but recommended for saving and viewing traces
 )
 
 agent.run("Which Agent Framework is the best??")

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -27,8 +27,7 @@ main_agent = AgentConfig(
 	model_id="gpt-4o-mini",
     tools=[search_web]
 )
-framework=AgentFramework("langchain")
-agent = AnyAgent.create(framework, main_agent, TracingConfig(output_dir="traces"))
+agent = AnyAgent.create("langchain", main_agent, TracingConfig(output_dir="traces"))
 
 agent.run("How many seconds would it take for a leopard at full speed to run through Pont des Arts?")
 ```

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -21,16 +21,14 @@ with user defined criteria. The steps for evaluating an agent are as follows:
 1. Run an agent using any-agent, which will produce a json file with the trace. For example
 
 ```python
-from any_agent import AgentConfig, AgentFramework, AnyAgent
-from any_agent.tracing import setup_tracing
+from any_agent import AgentConfig, AgentFramework, AnyAgent, TracingConfig
 from any_agent.tools import search_web
 main_agent = AgentConfig(
 	model_id="gpt-4o-mini",
     tools=[search_web]
 )
 framework=AgentFramework("langchain")
-tracing_path = setup_tracing(framework, "output")
-agent = AnyAgent.create(framework, main_agent)
+agent = AnyAgent.create(framework, main_agent, TracingConfig(output_dir="output"))
 
 agent.run("How many seconds would it take for a leopard at full speed to run through Pont des Arts?")
 ```

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -5,31 +5,29 @@ standardized [OpenTelemetry](https://opentelemetry.io/) traces for any of the su
 
 ## Example
 
-To enable tracing, call [`setup_tracing`][any_agent.tracing.setup_tracing] passing the selected framework.
+To enable tracing, add a TracingConfig object [`TracingConfig`][any_agent.config.TracingConfig] when creating an agent
 
 ```python
-from any_agent import AgentConfig, AgentFramework, AnyAgent
-from any_agent.tracing import setup_tracing
+from any_agent import AgentConfig, AgentFramework, AnyAgent, TracingConfig
 from any_agent.tools import search_web
 
 framework = AgentFramework("openai")
 
-setup_tracing(framework)
-
 agent = AnyAgent.create(
-        framework,
-        AgentConfig(
+        agent_framework=framework,
+        agent_config=AgentConfig(
                 model_id="gpt-4o",
-                tools=[search_web]
-            )
-        )
+                tools=[search_web],
+        ),
+        tracing=TracingConfig(enabled=True)
+      )
 agent.run("Which agent framework is the best?")
 ```
 
 ### Outputs
 
-[`setup_tracing`][any_agent.tracing.setup_tracing] will produce standardized console output regardless of the
-framework used.
+Tracing will output standardized console output regardless of the
+framework used, and will also save the trace as a json file in the directory set by the TracingConfig object. The file path of the trace is stored in the Agent.trace_filepath member variable.
 
 ```console
 ──────────────────────────────────────────────────────────────────────────── LLM ─────────────────────────────────────────────────────────────────────────────
@@ -61,20 +59,6 @@ input: {'query': 'best agent framework 2023'}
 │ Langflow; LangGraph; LlamaIndex; n8n ... Comparing Open-Source AI Agent Frameworks - Langfuse Blog This post offers an in-depth look at some of the        │
 ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-```
-
-You can configure the behavior of the console output using [`TracingConfig`][any_agent.config.TracingConfig]:
-
-```python
-from any_agent.config import TracingConfig
-
-setup_tracing(
-  agent_framework=AgentFramework("langchain"),
-  tracing_config=TracingConfig(
-    llm=None,  # Setting to None disables this `openinference.span.kind`
-    tool="purple",  # Change the color used to display
-  )
-)
 ```
 
 In addition, an output JSON will be stored in the selected `output_dir`, which is `"traces"` by default:
@@ -163,5 +147,4 @@ In addition, an output JSON will be stored in the selected `output_dir`, which i
       "schema_url": ""
     }
   },
-  ...
 ```

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -19,7 +19,7 @@ agent = AnyAgent.create(
                 model_id="gpt-4o",
                 tools=[search_web],
         ),
-        tracing=TracingConfig(enabled=True)
+        tracing=TracingConfig()
       )
 agent.run("Which agent framework is the best?")
 ```

--- a/src/any_agent/__init__.py
+++ b/src/any_agent/__init__.py
@@ -1,4 +1,4 @@
-from .config import AgentConfig, AgentFramework
+from .config import AgentConfig, AgentFramework, TracingConfig
 from .frameworks.any_agent import AnyAgent
 
-__all__ = ["AnyAgent", "AgentConfig", "AgentFramework"]
+__all__ = ["AnyAgent", "AgentConfig", "AgentFramework", "TracingConfig"]

--- a/src/any_agent/config.py
+++ b/src/any_agent/config.py
@@ -42,7 +42,7 @@ class MCPSseParams(BaseModel):
 
 
 class TracingConfig(BaseModel):
-    output_dir: str = "traces"
+    output_dir: str | None = "traces"  # None for no json saved trace
     llm: str | None = "yellow"
     tool: str | None = "blue"
     agent: str | None = None

--- a/src/any_agent/config.py
+++ b/src/any_agent/config.py
@@ -27,6 +27,7 @@ class MCPSseParams(BaseModel):
 
 
 class TracingConfig(BaseModel):
+    output_dir: str = "traces"
     llm: str | None = "yellow"
     tool: str | None = "blue"
     agent: str | None = None

--- a/src/any_agent/frameworks/agno.py
+++ b/src/any_agent/frameworks/agno.py
@@ -46,7 +46,7 @@ class AgnoAgent(AnyAgent):
             **agent_config.model_args or {},
         )
 
-    async def _load_agent(self) -> None:
+    async def load_agent(self) -> None:
         if not self.managed_agents and not self.config.tools:
             self.config.tools = [
                 search_web,

--- a/src/any_agent/frameworks/google.py
+++ b/src/any_agent/frameworks/google.py
@@ -45,7 +45,7 @@ class GoogleAgent(AnyAgent):
         """Get the model configuration for a Google agent."""
         return LiteLlm(model=agent_config.model_id, **agent_config.model_args or {})
 
-    async def _load_agent(self) -> None:
+    async def load_agent(self) -> None:
         """Load the Google agent with the given configuration."""
         if not self.managed_agents and not self.config.tools:
             self.config.tools = [

--- a/src/any_agent/frameworks/langchain.py
+++ b/src/any_agent/frameworks/langchain.py
@@ -61,7 +61,7 @@ class LangchainAgent(AnyAgent):
             model_type(model=agent_config.model_id, **agent_config.model_args or {}),
         )
 
-    async def _load_agent(self) -> None:
+    async def load_agent(self) -> None:
         """Load the LangChain agent with the given configuration."""
         if not self.managed_agents and not self.config.tools:
             self.config.tools = [

--- a/src/any_agent/frameworks/llama_index.py
+++ b/src/any_agent/frameworks/llama_index.py
@@ -67,7 +67,7 @@ class LlamaIndexAgent(AnyAgent):
 
         return imported_tools
 
-    async def _load_agent(self) -> None:
+    async def load_agent(self) -> None:
         """Load the LLamaIndex agent with the given configuration."""
         if not self.managed_agents and not self.config.tools:
             self.config.tools = [

--- a/src/any_agent/frameworks/openai.py
+++ b/src/any_agent/frameworks/openai.py
@@ -58,7 +58,7 @@ class OpenAIAgent(AnyAgent):
             openai_client=external_client,
         )
 
-    async def _load_agent(self) -> None:
+    async def load_agent(self) -> None:
         """Load the OpenAI agent with the given configuration."""
         if not agents_available:
             msg = "You need to `pip install openai-agents` to use this agent"

--- a/src/any_agent/frameworks/smolagents.py
+++ b/src/any_agent/frameworks/smolagents.py
@@ -55,7 +55,7 @@ class SmolagentsAgent(AnyAgent):
             tools.extend(mcp_server.tools)
         return tools
 
-    async def _load_agent(self) -> None:
+    async def load_agent(self) -> None:
         """Load the Smolagents agent with the given configuration."""
         if not self.managed_agents and not self.config.tools:
             self.config.tools = [

--- a/src/any_agent/tracing.py
+++ b/src/any_agent/tracing.py
@@ -136,8 +136,7 @@ def setup_tracing(
 
     Args:
         agent_framework (AgentFramework): The type of agent being used.
-        output_dir (str): The directory where the traces will be stored.
-            Defaults to "traces".
+        tracing_config (TracingConfig): Configuration for tracing, including output directory and styles.
 
     Returns:
         str: The name of the JSON file where traces will be stored.

--- a/src/any_agent/tracing.py
+++ b/src/any_agent/tracing.py
@@ -106,16 +106,17 @@ def _get_tracer_provider(
     agent_framework: AgentFramework,
     tracing_config: TracingConfig,
 ) -> tuple[TracerProvider, str]:
-    if not os.path.exists(tracing_config.output_dir):
-        os.makedirs(tracing_config.output_dir)
-    timestamp = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
-
     tracer_provider = TracerProvider()
-
-    file_name = f"{tracing_config.output_dir}/{agent_framework.value}-{timestamp}.json"
-    json_file_exporter = JsonFileSpanExporter(file_name=file_name)
-    span_processor = SimpleSpanProcessor(json_file_exporter)
-    tracer_provider.add_span_processor(span_processor)
+    if tracing_config.output_dir is not None:
+        if not os.path.exists(tracing_config.output_dir):
+            os.makedirs(tracing_config.output_dir)
+        timestamp = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+        file_name = (
+            f"{tracing_config.output_dir}/{agent_framework.value}-{timestamp}.json"
+        )
+        json_file_exporter = JsonFileSpanExporter(file_name=file_name)
+        span_processor = SimpleSpanProcessor(json_file_exporter)
+        tracer_provider.add_span_processor(span_processor)
 
     # This is what will log all the span info to stdout: We turn off the agent sdk specific logging so that
     # the user sees a similar logging format for whichever agent they are using under the hood.

--- a/tests/integration/test_load_and_run_agent.py
+++ b/tests/integration/test_load_and_run_agent.py
@@ -5,7 +5,6 @@ import pytest
 
 from any_agent import AgentConfig, AgentFramework, AnyAgent
 from any_agent.tools import search_web
-from any_agent.tracing import setup_tracing
 
 frameworks = list(AgentFramework)
 
@@ -25,11 +24,6 @@ def test_load_and_run_agent(framework: AgentFramework, tmp_path: Path) -> None:
     kwargs["model_id"] = "gpt-4.1-nano"
     if "OPENAI_API_KEY" not in os.environ:
         pytest.skip(f"OPENAI_API_KEY needed for {framework}")
-
-    # Agno not yet supported https://github.com/Arize-ai/openinference/issues/1302
-    # Google ADK not yet supported https://github.com/Arize-ai/openinference/issues/1506
-    if framework not in ("agno", "google"):
-        setup_tracing(agent_framework, str(tmp_path / "traces"))
 
     agent_config = AgentConfig(
         tools=[search_web],

--- a/tests/integration/test_load_and_run_multi_agent.py
+++ b/tests/integration/test_load_and_run_multi_agent.py
@@ -5,7 +5,6 @@ import pytest
 
 from any_agent import AgentConfig, AgentFramework, AnyAgent
 from any_agent.tools import search_web, show_final_answer, visit_webpage
-from any_agent.tracing import setup_tracing
 
 
 @pytest.mark.parametrize(
@@ -24,9 +23,6 @@ def test_load_and_run_multi_agent(framework: str, tmp_path: Path) -> None:
     kwargs["model_id"] = "gpt-4.1-nano"
     if "OPENAI_API_KEY" not in os.environ:
         pytest.skip(f"OPENAI_API_KEY needed for {framework}")
-
-    if framework != "google":
-        setup_tracing(agent_framework, str(tmp_path / "traces"))
 
     main_agent = AgentConfig(
         instructions="Use the available agents to complete the task.",

--- a/tests/unit/frameworks/test_anyagent.py
+++ b/tests/unit/frameworks/test_anyagent.py
@@ -1,0 +1,66 @@
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from any_agent import AgentConfig, AgentFramework, AnyAgent
+from any_agent.config import TracingConfig
+
+
+# Test all supported frameworks
+@pytest.mark.parametrize("framework", list(AgentFramework))
+def test_load_agent_tracing(tmp_path: Path, framework: AgentFramework) -> None:
+    mock_agent = MagicMock(spec=AnyAgent)
+    mock_agent.load_agent = AsyncMock(return_value=None)
+    mock_agent.trace_filepath = None
+
+    # Dynamically create the import path based on the framework
+    agent_class_path = _get_agent_class_path(framework)
+
+    # Skip frameworks that don't support tracing
+    if framework in (AgentFramework.AGNO, AgentFramework.GOOGLE):
+        return
+
+    with patch(agent_class_path, return_value=mock_agent):
+        agent = AnyAgent.create(
+            agent_framework=framework,
+            agent_config=AgentConfig(
+                model_id="gpt-4o",
+            ),
+            tracing=TracingConfig(output_dir=str(tmp_path)),
+        )
+        # the agent.trace_filepath should be a file that exists
+        assert agent.trace_filepath is not None
+        assert os.path.exists(agent.trace_filepath)
+
+
+@pytest.mark.parametrize("framework", list(AgentFramework))
+def test_load_agent_no_tracing(framework: AgentFramework) -> None:
+    mock_agent = MagicMock(spec=AnyAgent)
+    mock_agent.load_agent = AsyncMock(return_value=None)
+    mock_agent.trace_filepath = None
+
+    # Dynamically create the import path based on the framework
+    agent_class_path = _get_agent_class_path(framework)
+
+    with patch(agent_class_path, return_value=mock_agent):
+        agent = AnyAgent.create(
+            agent_framework=framework,
+            agent_config=AgentConfig(model_id="gpt-4o"),
+        )
+        # the agent.trace_filepath should be None
+        assert agent.trace_filepath is None
+
+
+def _get_agent_class_path(framework: AgentFramework) -> str:
+    """Helper function to get the import path for an agent class based on framework."""
+    framework_map = {
+        AgentFramework.SMOLAGENTS: "any_agent.frameworks.smolagents.SmolagentsAgent",
+        AgentFramework.LANGCHAIN: "any_agent.frameworks.langchain.LangchainAgent",
+        AgentFramework.OPENAI: "any_agent.frameworks.openai.OpenAIAgent",
+        AgentFramework.LLAMAINDEX: "any_agent.frameworks.llama_index.LlamaIndexAgent",
+        AgentFramework.GOOGLE: "any_agent.frameworks.google.GoogleAgent",
+        AgentFramework.AGNO: "any_agent.frameworks.agno.AgnoAgent",
+    }
+    return framework_map[framework]

--- a/tests/unit/test_unit_tracing.py
+++ b/tests/unit/test_unit_tracing.py
@@ -28,7 +28,7 @@ def test_get_tracer_provider(tmp_path: Path) -> None:
 
 
 def test_invalid_agent_framework(tmp_path: Path) -> None:
-    with pytest.raises(ValueError, match="Unsupported agent type"):
+    with pytest.raises(ValueError, match="Unsupported agent framework"):
         setup_tracing(
             MagicMock(),
             tracing_config=TracingConfig(output_dir=str(tmp_path / "traces")),

--- a/tests/unit/test_unit_tracing.py
+++ b/tests/unit/test_unit_tracing.py
@@ -16,9 +16,10 @@ def test_get_tracer_provider(tmp_path: Path) -> None:
         patch("any_agent.tracing.TracerProvider", mock_tracer_provider),
     ):
         _get_tracer_provider(
-            output_dir=tmp_path / "traces",
             agent_framework=AgentFramework.OPENAI,
-            tracing_config=TracingConfig(),
+            tracing_config=TracingConfig(
+                output_dir=str(tmp_path / "traces"),
+            ),
         )
         assert (tmp_path / "traces").exists()
         mock_trace.set_tracer_provider.assert_called_once_with(
@@ -28,4 +29,4 @@ def test_get_tracer_provider(tmp_path: Path) -> None:
 
 def test_invalid_agent_framework(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="Unsupported agent type"):
-        setup_tracing(MagicMock(), tmp_path / "traces")
+        setup_tracing(MagicMock(), tracing_config=TracingConfig())


### PR DESCRIPTION
In order to simplify the process for users, refactor setup_tracing to be a part of creating an agent, so that the user doesn't need to call setup_tracing, they can pass a TracingConfig object into the create function, and then the trace path will be stored as a member variable of the AnyAgent object.