### PR TITLE
chore(lint): use uv for pre-commit installs

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,7 +21,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install pre-commit
-        run: pip install pre-commit
+        run: pip install pre-commit~=4.2 pre-commit-uv~=4.1
 
       - uses: actions/cache@v4
         with:
@@ -29,4 +29,6 @@ jobs:
           key: pre-commit-4|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
 
       - name: pre-commit
+        env:
+          FORCE_PRE_COMMIT_UV_PATCH: 1
         run: pre-commit run --all-files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,8 @@ tests = [
 
 dev = [
   "any-agent[docs,tests]",
-  "pre-commit",
+  "pre-commit~=4.2",
+  "pre-commit-uv~=4.1"
 ]
 
 [project.urls]


### PR DESCRIPTION
- Specify exact versions for pre-commit and pre-commit-uv in
  both the workflow and pyproject.toml to ensure compatibility
  and avoid potential issues with future updates.