### PR TITLE
If the interaction is empty, don't log the bars

### DIFF
--- a/src/any_agent/tracing.py
+++ b/src/any_agent/tracing.py
@@ -75,7 +75,7 @@ class RichConsoleSpanExporter(SpanExporter):
 
                 style = getattr(self.tracing_config, span_kind.lower(), None)
 
-                if not style:
+                if not style or interaction == {}:
                     continue
 
                 self.console.rule(


### PR DESCRIPTION
Sometimes the interaction is an empty dict, so there's nothing to log