### PR TITLE
fix: langchain mcp hang

### DIFF
--- a/src/any_agent/config.py
+++ b/src/any_agent/config.py
@@ -33,6 +33,8 @@ class MCPStdioParams(BaseModel):
     command: str
     args: Sequence[str]
     tools: Sequence[str] | None = None
+    client_session_timeout_seconds: float | None = 5
+    """the read timeout passed to the MCP ClientSession."""
 
     model_config = ConfigDict(frozen=True)
 
@@ -41,6 +43,8 @@ class MCPSseParams(BaseModel):
     url: str
     headers: Mapping[str, str] | None = None
     tools: Sequence[str] | None = None
+    client_session_timeout_seconds: float | None = 5
+    """the read timeout passed to the MCP ClientSession."""
 
     model_config = ConfigDict(frozen=True)
 

--- a/src/any_agent/tools/mcp/frameworks/langchain.py
+++ b/src/any_agent/tools/mcp/frameworks/langchain.py
@@ -1,6 +1,7 @@
 import os
 from abc import ABC, abstractmethod
 from contextlib import suppress
+from datetime import timedelta
 from typing import Any, Literal
 
 from any_agent.config import AgentFramework, MCPSseParams, MCPStdioParams
@@ -35,7 +36,13 @@ class LangchainMCPServerBase(MCPServerBase, ABC):
 
         stdio, write = await self._exit_stack.enter_async_context(self.client)
 
-        client_session = ClientSession(stdio, write)
+        client_session = ClientSession(
+            stdio,
+            write,
+            timedelta(seconds=self.mcp_tool.client_session_timeout_seconds)
+            if self.mcp_tool.client_session_timeout_seconds
+            else None,
+        )
         session = await self._exit_stack.enter_async_context(client_session)
 
         await session.initialize()


### PR DESCRIPTION
Langchain was the only framework where the bug was in our code. For the rest of them, we need to pipe our config setting into their frameworks once the bug fix propogates to their codebase