### PR TITLE
Tracing as a class

### DIFF
--- a/src/any_agent/config.py
+++ b/src/any_agent/config.py
@@ -2,7 +2,7 @@ from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from enum import Enum, auto
 from typing import Any, Self
 
-from pydantic import BaseModel, ConfigDict, Field,  model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class AgentFramework(str, Enum):
@@ -60,10 +60,11 @@ class TracingConfig(BaseModel):
     chain: str | None = None
     cost_info: bool = True
 
-    @model_validator(mode='after')
+    @model_validator(mode="after")
     def validate_enable_flags(self) -> Self:
         if not self.enable_console and not self.enable_file:
-            raise ValueError("At least one of enable_console or enable_file must be true")
+            msg = "At least one of enable_console or enable_file must be true"
+            raise ValueError(msg)
         return self
 
 

--- a/src/any_agent/config.py
+++ b/src/any_agent/config.py
@@ -2,7 +2,7 @@ from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from enum import Enum, auto
 from typing import Any, Self
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field,  model_validator
 
 
 class AgentFramework(str, Enum):
@@ -51,12 +51,20 @@ class MCPSseParams(BaseModel):
 
 class TracingConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
-    output_dir: str | None = "traces"  # None for no json saved trace
+    output_dir: str = "traces"  # None for no json saved trace
+    enable_console: bool = True
+    enable_file: bool = True
     llm: str | None = "yellow"
     tool: str | None = "blue"
     agent: str | None = None
     chain: str | None = None
     cost_info: bool = True
+
+    @model_validator(mode='after')
+    def validate_enable_flags(self) -> Self:
+        if not self.enable_console and not self.enable_file:
+            raise ValueError("At least one of enable_console or enable_file must be true")
+        return self
 
 
 MCPParams = MCPStdioParams | MCPSseParams

--- a/src/any_agent/frameworks/any_agent.py
+++ b/src/any_agent/frameworks/any_agent.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, assert_never
 from any_agent.config import AgentConfig, AgentFramework, Tool, TracingConfig
 from any_agent.logging import logger
 from any_agent.tools.wrappers import _wrap_tools
-from any_agent.tracing import setup_tracing
+from any_agent.tracing import Tracer
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -28,8 +28,8 @@ class AnyAgent(ABC):
     ):
         self.config = config
         self.managed_agents = managed_agents
-        self.trace_filepath: str | None = None
         self._mcp_servers: list[MCPServerBase] = []
+        self._tracer: Tracer | None = None
 
     async def _load_tools(
         self, tools: Sequence[Tool]
@@ -107,19 +107,27 @@ class AnyAgent(ABC):
         framework = AgentFramework.from_string(agent_framework)
         agent_cls = cls._get_agent_type_by_framework(agent_framework)
         agent = agent_cls(agent_config, managed_agents=managed_agents)
+
         if tracing is not None:
             # Agno not yet supported https://github.com/Arize-ai/openinference/issues/1302
             # Google ADK not yet supported https://github.com/Arize-ai/openinference/issues/1506
-            if framework in (AgentFramework.AGNO, AgentFramework.GOOGLE):
+            if agent_framework in (AgentFramework.AGNO, AgentFramework.GOOGLE):
                 logger.warning(
                     "Tracing is not yet supported for AGNO and GOOGLE frameworks. "
                 )
             else:
-                agent.trace_filepath = setup_tracing(framework, tracing)
+                agent._tracer = Tracer(framework, tracing)
+
         await agent.load_agent()
         return agent
 
-    def run(self, prompt: str, **kwargs) -> Any:  # type: ignore[no-untyped-def]
+    @property
+    def trace_filepath(self) -> str | None:
+        """Return the trace filepath."""
+        if self._tracer is not None:
+            return self._tracer.trace_filepath
+        return None
+
         """Run the agent with the given prompt."""
         return asyncio.get_event_loop().run_until_complete(
             self.run_async(prompt, **kwargs)

--- a/src/any_agent/frameworks/any_agent.py
+++ b/src/any_agent/frameworks/any_agent.py
@@ -111,7 +111,7 @@ class AnyAgent(ABC):
         if tracing is not None:
             # Agno not yet supported https://github.com/Arize-ai/openinference/issues/1302
             # Google ADK not yet supported https://github.com/Arize-ai/openinference/issues/1506
-            if agent_framework in (AgentFramework.AGNO, AgentFramework.GOOGLE):
+            if framework in (AgentFramework.AGNO, AgentFramework.GOOGLE):
                 logger.warning(
                     "Tracing is not yet supported for AGNO and GOOGLE frameworks. "
                 )

--- a/src/any_agent/frameworks/any_agent.py
+++ b/src/any_agent/frameworks/any_agent.py
@@ -128,6 +128,7 @@ class AnyAgent(ABC):
             return self._tracer.trace_filepath
         return None
 
+    def run(self, prompt: str, **kwargs) -> Any:  # type: ignore[no-untyped-def]
         """Run the agent with the given prompt."""
         return asyncio.get_event_loop().run_until_complete(
             self.run_async(prompt, **kwargs)

--- a/src/any_agent/tracing.py
+++ b/src/any_agent/tracing.py
@@ -130,60 +130,6 @@ class RichConsoleSpanExporter(SpanExporter):  # noqa: D101
         return SpanExportResult.SUCCESS
 
 
-def _get_tracer_provider(
-    agent_framework: AgentFramework,
-    tracing_config: TracingConfig,
-) -> tuple[TracerProvider, str]:
-    tracer_provider = TracerProvider()
-    if tracing_config.output_dir is not None:
-        if not os.path.exists(tracing_config.output_dir):
-            os.makedirs(tracing_config.output_dir)
-        timestamp = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
-        file_name = (
-            f"{tracing_config.output_dir}/{agent_framework.name}-{timestamp}.json"
-        )
-        json_file_exporter = JsonFileSpanExporter(file_name=file_name)
-        span_processor = SimpleSpanProcessor(json_file_exporter)
-        tracer_provider.add_span_processor(span_processor)
-
-    # This is what will log all the span info to stdout: We turn off the agent sdk specific logging so that
-    # the user sees a similar logging format for whichever agent they are using under the hood.
-    processor = BatchSpanProcessor(
-        RichConsoleSpanExporter(agent_framework, tracing_config),
-    )
-    tracer_provider.add_span_processor(processor)
-    trace.set_tracer_provider(tracer_provider)
-
-    return tracer_provider, file_name
-
-
-def setup_tracing(
-    agent_framework: AgentFramework,
-    tracing_config: TracingConfig,
-) -> str:
-    """Set up tracing for `agent_framework` using `openinference.instrumentation`.
-
-    Args:
-        agent_framework (AgentFramework): The type of agent being used.
-        tracing_config (TracingConfig): Configuration for tracing, including output directory and styles.
-
-    Returns:
-        str: The name of the JSON file where traces will be stored.
-
-    """
-    agent_framework_ = AgentFramework.from_string(agent_framework)
-
-    tracer_provider, file_name = _get_tracer_provider(
-        agent_framework,
-        tracing_config,
-    )
-
-    instrumenter = _get_instrumenter_by_framework(agent_framework_)
-    instrumenter.instrument(tracer_provider=tracer_provider)
-
-    return file_name
-
-
 class Instrumenter(Protocol):  # noqa: D101
     def instrument(self, *, tracer_provider: TracerProvider) -> None: ...  # noqa: D102
 
@@ -214,3 +160,59 @@ def _get_instrumenter_by_framework(framework: AgentFramework) -> Instrumenter:
         raise NotImplementedError(msg)
 
     assert_never(framework)
+
+
+class Tracer:
+    """A class that manages tracing for an agent."""
+
+    def __init__(
+        self,
+        agent_framework: AgentFramework,
+        tracing_config: TracingConfig,
+    ):
+        self.agent_framework = agent_framework
+        self.tracing_config = tracing_config
+        if self.tracing_config.enable_file:
+            if not os.path.exists(self.tracing_config.output_dir):
+                os.makedirs(self.tracing_config.output_dir)
+            timestamp = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+            self.trace_filepath = f"{self.tracing_config.output_dir}/{self.agent_framework.name}-{timestamp}.json"
+        else:
+            self.trace_filepath = None
+
+        self._setup_tracing()
+
+    def _setup_tracing(self) -> None:
+        """Set up tracing for the agent."""
+        tracer_provider = TracerProvider()
+
+        if self.tracing_config.enable_file:
+            json_file_exporter = JsonFileSpanExporter(file_name=self.trace_filepath)
+            span_processor = SimpleSpanProcessor(json_file_exporter)
+            tracer_provider.add_span_processor(span_processor)
+
+        if self.tracing_config.enable_console:
+            processor = BatchSpanProcessor(
+                RichConsoleSpanExporter(self.agent_framework, self.tracing_config),
+            )
+            tracer_provider.add_span_processor(processor)
+
+        trace.set_tracer_provider(tracer_provider)
+
+        instrumenter = _get_instrumenter_by_framework(self.agent_framework)
+        instrumenter.instrument(tracer_provider=tracer_provider)
+
+    @property
+    def is_enabled(self) -> bool:
+        """Whether tracing is enabled."""
+        return self.tracing_config.enable_file or self.tracing_config.enable_console
+
+    def get_trace(self) -> dict[str, Any] | None:
+        """Return the trace data if file tracing is enabled."""
+        if self.trace_filepath:
+            try:
+                with open(self.trace_filepath, "r") as f:
+                    return json.load(f)
+            except json.JSONDecodeError:
+                logger.warning("Failed to decode JSON trace file.")
+        return None

--- a/tests/unit/frameworks/test_any_agent.py
+++ b/tests/unit/frameworks/test_any_agent.py
@@ -22,23 +22,20 @@ def test_create_any_with_invalid_string() -> None:
         AnyAgent.create("non-existing", AgentConfig(model_id="gpt-4o"))
 
 
-# Test all supported frameworks
-@pytest.mark.parametrize("framework", list(AgentFramework))
-def test_load_agent_tracing(tmp_path: Path, framework: AgentFramework) -> None:
+def test_load_agent_tracing(tmp_path: Path, agent_framework: AgentFramework) -> None:
     mock_agent = MagicMock(spec=AnyAgent)
     mock_agent.load_agent = AsyncMock(return_value=None)
-    mock_agent.trace_filepath = None
 
     # Dynamically create the import path based on the framework
-    agent_class_path = _get_agent_class_path(framework)
+    agent_class_path = _get_agent_class_path(agent_framework)
 
     # Skip frameworks that don't support tracing
-    if framework in (AgentFramework.AGNO, AgentFramework.GOOGLE):
+    if agent_framework in (AgentFramework.AGNO, AgentFramework.GOOGLE):
         return
 
     with patch(agent_class_path, return_value=mock_agent):
         agent = AnyAgent.create(
-            agent_framework=framework,
+            agent_framework=agent_framework,
             agent_config=AgentConfig(
                 model_id="gpt-4o",
             ),

--- a/tests/unit/test_unit_tracing.py
+++ b/tests/unit/test_unit_tracing.py
@@ -4,10 +4,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from any_agent.config import AgentFramework, TracingConfig
-from any_agent.tracing import _get_tracer_provider, setup_tracing
+from any_agent.tracing import Tracer
 
 
-def test_get_tracer_provider(tmp_path: Path) -> None:
+def test_tracer_initialization(tmp_path: Path) -> None:
     mock_trace = MagicMock()
     mock_tracer_provider = MagicMock()
 
@@ -15,21 +15,28 @@ def test_get_tracer_provider(tmp_path: Path) -> None:
         patch("any_agent.tracing.trace", mock_trace),
         patch("any_agent.tracing.TracerProvider", mock_tracer_provider),
     ):
-        _get_tracer_provider(
+        tracer = Tracer(
             agent_framework=AgentFramework.OPENAI,
             tracing_config=TracingConfig(
                 output_dir=str(tmp_path / "traces"),
             ),
         )
+
+        # Verify tracer was initialized correctly
+        assert tracer.agent_framework == AgentFramework.OPENAI
+        assert tracer.tracing_config.output_dir == str(tmp_path / "traces")
+        assert tracer.is_enabled is True
         assert (tmp_path / "traces").exists()
+
+        # Verify tracing was set up
         mock_trace.set_tracer_provider.assert_called_once_with(
             mock_tracer_provider.return_value,
         )
 
 
-def test_invalid_agent_framework(tmp_path: Path) -> None:
-    with pytest.raises(ValueError, match="Unsupported agent framework"):
-        setup_tracing(
-            MagicMock(),
-            tracing_config=TracingConfig(output_dir=str(tmp_path / "traces")),
+def test_tracer_with_unsupported_framework(tmp_path: Path) -> None:
+    with pytest.raises(NotImplementedError, match="AGNO tracing is not supported."):
+        Tracer(
+            agent_framework=AgentFramework.AGNO,
+            tracing_config=TracingConfig(output_dir=str(tmp_path / "traces"), enable_console=False),
         )

--- a/tests/unit/test_unit_tracing.py
+++ b/tests/unit/test_unit_tracing.py
@@ -38,5 +38,7 @@ def test_tracer_with_unsupported_framework(tmp_path: Path) -> None:
     with pytest.raises(NotImplementedError, match="AGNO tracing is not supported."):
         Tracer(
             agent_framework=AgentFramework.AGNO,
-            tracing_config=TracingConfig(output_dir=str(tmp_path / "traces"), enable_console=False),
+            tracing_config=TracingConfig(
+                output_dir=str(tmp_path / "traces"), enable_console=False
+            ),
         )


### PR DESCRIPTION
This is the beginnings of the changes to support

https://github.com/mozilla-ai/any-agent/issues/92 

and 

https://github.com/mozilla-ai/any-agent/issues/160

By storing the trace object as a member of the agent, we'll be able to access the trace information (and maybe the cost information from the traces, not sure yet) in a clean way. The existing implementation is storing the trace_filepath as a parameter of AnyAgent separate from the tracing functions, which imo is making our lives a little more complicated than it needs to be.