### PR TITLE
Consistent return no matter which agent framework

### DIFF
--- a/src/any_agent/__init__.py
+++ b/src/any_agent/__init__.py
@@ -1,4 +1,4 @@
 from .config import AgentConfig, AgentFramework, TracingConfig
-from .frameworks.any_agent import AnyAgent
+from .frameworks.any_agent import AgentResult, AnyAgent
 
-__all__ = ["AgentConfig", "AgentFramework", "AnyAgent", "TracingConfig"]
+__all__ = ["AgentConfig", "AgentFramework", "AgentResult", "AnyAgent", "TracingConfig"]

--- a/src/any_agent/frameworks/agno.py
+++ b/src/any_agent/frameworks/agno.py
@@ -1,12 +1,13 @@
 from typing import Any
 
 from any_agent.config import AgentConfig, AgentFramework
-from any_agent.frameworks.any_agent import AnyAgent
+from any_agent.frameworks.any_agent import AgentResult, AnyAgent
 from any_agent.logging import logger
 from any_agent.tools import search_web, visit_webpage
 
 try:
     from agno.agent import Agent
+    from agno.agent import RunResponse as AgnoRunResponse
     from agno.models.litellm import LiteLLM
     from agno.team.team import Team
 
@@ -94,9 +95,10 @@ class AgnoAgent(AnyAgent):
                 **self.config.agent_args or {},
             )
 
-    async def run_async(self, prompt: str, **kwargs) -> Any:  # type: ignore[no-untyped-def]
+    async def run_async(self, prompt: str, **kwargs: Any) -> AgentResult:
         if not self._agent:
             error_message = "Agent not loaded. Call load_agent() first."
             raise ValueError(error_message)
 
-        return await self._agent.arun(prompt, **kwargs)
+        result: AgnoRunResponse = await self._agent.arun(prompt, **kwargs)
+        return AgentResult(final_output=result.content, raw_responses=result.messages)

--- a/src/any_agent/frameworks/any_agent.py
+++ b/src/any_agent/frameworks/any_agent.py
@@ -4,6 +4,8 @@ import asyncio
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, assert_never
 
+from pydantic import BaseModel, ConfigDict
+
 from any_agent.config import AgentConfig, AgentFramework, Tool, TracingConfig
 from any_agent.logging import logger
 from any_agent.tools.wrappers import _wrap_tools
@@ -13,6 +15,15 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from any_agent.tools.mcp.mcp_server import MCPServerBase
+
+
+class AgentResult(BaseModel):
+    """Standardized output format for all agent frameworks."""
+
+    final_output: str | int | float | list[Any] | dict[Any, Any] | None
+    raw_responses: list[Any] | None
+
+    model_config = ConfigDict(extra="forbid")
 
 
 class AnyAgent(ABC):
@@ -128,7 +139,7 @@ class AnyAgent(ABC):
             return self._tracer.trace_filepath
         return None
 
-    def run(self, prompt: str, **kwargs) -> Any:  # type: ignore[no-untyped-def]
+    def run(self, prompt: str, **kwargs: Any) -> AgentResult:
         """Run the agent with the given prompt."""
         return asyncio.get_event_loop().run_until_complete(
             self.run_async(prompt, **kwargs)
@@ -139,7 +150,7 @@ class AnyAgent(ABC):
         """Load the agent instance."""
 
     @abstractmethod
-    async def run_async(self, prompt: str, **kwargs) -> Any:  # type: ignore[no-untyped-def]
+    async def run_async(self, prompt: str, **kwargs: Any) -> AgentResult:
         """Run the agent asynchronously with the given prompt."""
 
     @property

--- a/src/any_agent/frameworks/google.py
+++ b/src/any_agent/frameworks/google.py
@@ -1,9 +1,8 @@
 from collections.abc import Sequence
-from typing import Any
 from uuid import uuid4
 
 from any_agent.config import AgentConfig, AgentFramework
-from any_agent.frameworks.any_agent import AnyAgent
+from any_agent.frameworks.any_agent import AgentResult, AnyAgent
 from any_agent.logging import logger
 from any_agent.tools import search_web, visit_webpage
 
@@ -90,7 +89,7 @@ class GoogleAgent(AnyAgent):
         user_id: str | None = None,
         session_id: str | None = None,
         **kwargs,
-    ) -> Any:
+    ) -> AgentResult:
         """Run the Google agent with the given prompt."""
         if not self._agent:
             error_message = "Agent not loaded. Call load_agent() first."
@@ -122,4 +121,6 @@ class GoogleAgent(AnyAgent):
             session_id=session_id,
         )
         assert session, "Session should not be None"
-        return session.state.get("response", None)
+        response = session.state.get("response", None)
+
+        return AgentResult(final_output=response, raw_responses=session.events)

--- a/src/any_agent/frameworks/openai.py
+++ b/src/any_agent/frameworks/openai.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from any_agent.config import AgentConfig, AgentFramework
-from any_agent.frameworks.any_agent import AnyAgent
+from any_agent.frameworks.any_agent import AgentResult, AnyAgent
 from any_agent.tools import search_web, visit_webpage
 
 try:
@@ -115,10 +115,14 @@ class OpenAIAgent(AnyAgent):
             non_mcp_tools.append(tool)
         return non_mcp_tools
 
-    async def run_async(self, prompt: str, **kwargs) -> Any:  # type: ignore[no-untyped-def]
+    async def run_async(self, prompt: str, **kwargs: Any) -> AgentResult:
         """Run the OpenAI agent with the given prompt asynchronously."""
         if not self._agent:
             error_message = "Agent not loaded. Call load_agent() first."
             raise ValueError(error_message)
 
-        return await Runner.run(self._agent, prompt, **kwargs)
+        result = await Runner.run(self._agent, prompt, **kwargs)
+        return AgentResult(
+            final_output=result.final_output,
+            raw_responses=result.raw_responses,
+        )

--- a/src/any_agent/frameworks/smolagents.py
+++ b/src/any_agent/frameworks/smolagents.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Any
 
 from any_agent.config import AgentConfig, AgentFramework
-from any_agent.frameworks.any_agent import AnyAgent
+from any_agent.frameworks.any_agent import AgentResult, AnyAgent
 from any_agent.tools import search_web, visit_webpage
 
 try:
@@ -99,10 +99,13 @@ class SmolagentsAgent(AnyAgent):
         if self.config.instructions:
             self._agent.prompt_templates["system_prompt"] = self.config.instructions
 
-    async def run_async(self, prompt: str, **kwargs) -> Any:  # type: ignore[no-untyped-def]
+    async def run_async(self, prompt: str, **kwargs: Any) -> AgentResult:
         """Run the Smolagents agent with the given prompt."""
         if not self._agent:
             error_message = "Agent not loaded. Call load_agent() first."
             raise ValueError(error_message)
 
-        return self._agent.run(prompt, **kwargs)
+        result = self._agent.run(prompt, **kwargs)
+        return AgentResult(
+            final_output=result, raw_responses=self._agent.input_messages
+        )

--- a/tests/integration/test_load_and_run_agent.py
+++ b/tests/integration/test_load_and_run_agent.py
@@ -39,6 +39,11 @@ def test_load_and_run_agent(agent_framework: AgentFramework, tmp_path: Path) -> 
     )
     result = agent.run("Which agent framework is the best?")
     assert result
+    assert result.final_output
+    if agent_framework not in [AgentFramework.LLAMA_INDEX]:
+        # Llama Index doesn't currently give back raw_responses.
+        assert result.raw_responses
+        assert len(result.raw_responses) > 0
     if agent_framework not in (
         AgentFramework.AGNO,
         AgentFramework.GOOGLE,

--- a/tests/integration/test_load_and_run_multi_agent.py
+++ b/tests/integration/test_load_and_run_multi_agent.py
@@ -68,3 +68,8 @@ def test_load_and_run_multi_agent(
     result = agent.run("Which agent framework is the best?")
 
     assert result
+    assert result.final_output
+    if agent_framework not in [AgentFramework.LLAMA_INDEX]:
+        # Llama Index doesn't currently give back raw_responses.
+        assert result.raw_responses
+        assert len(result.raw_responses) > 0

--- a/tests/integration/test_mcp.py
+++ b/tests/integration/test_mcp.py
@@ -54,3 +54,8 @@ def test_mcp(agent_framework: AgentFramework, tmp_path) -> None:  # type: ignore
         content = f.read()
     assert content == str(datetime.now().year)
     assert result
+    assert result.final_output
+    if agent_framework not in [AgentFramework.LLAMA_INDEX]:
+        # Llama Index doesn't currently give back raw_responses.
+        assert result.raw_responses
+        assert len(result.raw_responses) > 0

--- a/tests/unit/frameworks/test_smolagents.py
+++ b/tests/unit/frameworks/test_smolagents.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 

--- a/tests/unit/frameworks/test_smolagents.py
+++ b/tests/unit/frameworks/test_smolagents.py
@@ -80,7 +80,7 @@ def test_load_smolagents_agent_missing() -> None:
 
 def test_run_smolagent_custom_args() -> None:
     mock_agent = MagicMock()
-    mock_agent.return_value = AsyncMock()
+    mock_agent.return_value = MagicMock()
     with (
         patch(f"smolagents.{DEFAULT_AGENT_TYPE}", mock_agent),
         patch(f"smolagents.{DEFAULT_MODEL_CLASS}"),


### PR DESCRIPTION
Now when the Agent.run returns, you always can get a reasonable answer at result.final_output, and some tracing when available at `raw_responses`.

We'll add some more keys to this output object soon, like execution time, cost, etc. 

We also will improve on raw_responses by populating it with the normalized trace object. But this PR should be nice enough to get us started.