### PR TITLE
feat: Support `agent_type` and `model_type` in every framework.

### DIFF
--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -9,7 +9,7 @@
 
     In those cases, you might want to instead copy-paste and **extend** the default
     instructions.
-    For example, check the [`CodeAgent` default instructions](https://github.com/huggingface/smolagents/blob/main/src/smolagents/prompts/code_agent.yaml) in `smolagents`.
+    For example, check the [`ToolCallingAgent` default instructions](https://github.com/huggingface/smolagents/blob/main/src/smolagents/prompts/toolcalling_agent.yaml) in `smolagents`.
 
 
 ```python

--- a/src/any_agent/config.py
+++ b/src/any_agent/config.py
@@ -107,7 +107,7 @@ class AgentConfig(BaseModel):
     instructions: str | None = None
     tools: Sequence[Tool] = Field(default_factory=list)
     handoff: bool = False
-    agent_type: str | None = None
+    agent_type: Callable[..., Any] | None = None
     agent_args: MutableMapping[str, Any] | None = None
-    model_type: str | None = None
+    model_type: Callable[..., Any] | None = None
     model_args: MutableMapping[str, Any] | None = None

--- a/src/any_agent/frameworks/google.py
+++ b/src/any_agent/frameworks/google.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 from any_agent.config import AgentConfig, AgentFramework, TracingConfig
@@ -7,15 +8,19 @@ from any_agent.logging import logger
 from any_agent.tools import search_web, visit_webpage
 
 try:
-    from google.adk.agents import Agent
+    from google.adk.agents.llm_agent import LlmAgent
     from google.adk.models.lite_llm import LiteLlm
     from google.adk.runners import InMemoryRunner
     from google.adk.tools.agent_tool import AgentTool
     from google.genai import types
 
+    DEFAULT_MODEL_TYPE = LiteLlm
     adk_available = True
 except ImportError:
     adk_available = False
+
+if TYPE_CHECKING:
+    from google.adk.models.base_llm import BaseLlm
 
 
 class GoogleAgent(AnyAgent):
@@ -28,15 +33,16 @@ class GoogleAgent(AnyAgent):
         tracing: TracingConfig | None = None,
     ):
         super().__init__(config, managed_agents, tracing)
-        self._agent: Agent | None = None
+        self._agent: LlmAgent | None = None
 
     @property
     def framework(self) -> AgentFramework:
         return AgentFramework.GOOGLE
 
-    def _get_model(self, agent_config: AgentConfig) -> LiteLlm:
+    def _get_model(self, agent_config: AgentConfig) -> "BaseLlm":
         """Get the model configuration for a Google agent."""
-        return LiteLlm(
+        model_type = agent_config.model_type or DEFAULT_MODEL_TYPE
+        return model_type(
             model=agent_config.model_id,
             api_key=agent_config.api_key,
             api_base=agent_config.api_base,
@@ -61,7 +67,8 @@ class GoogleAgent(AnyAgent):
             for managed_agent in self.managed_agents:
                 managed_tools, _ = await self._load_tools(managed_agent.tools)
 
-                instance = Agent(
+                agent_type = managed_agent.agent_type or LlmAgent
+                instance = agent_type(
                     name=managed_agent.name,
                     instruction=managed_agent.instructions or "",
                     model=self._get_model(managed_agent),
@@ -73,13 +80,13 @@ class GoogleAgent(AnyAgent):
                     sub_agents_instanced.append(instance)
                 else:
                     tools.append(AgentTool(instance))
-
-        self._agent = Agent(
+        agent_type = self.config.agent_type or LlmAgent
+        self._agent = agent_type(
             name=self.config.name,
             instruction=self.config.instructions or "",
             model=self._get_model(self.config),
             tools=tools,
-            sub_agents=sub_agents_instanced,  # type: ignore[arg-type]
+            sub_agents=sub_agents_instanced,
             **self.config.agent_args or {},
             output_key="response",
         )

--- a/src/any_agent/frameworks/llama_index.py
+++ b/src/any_agent/frameworks/llama_index.py
@@ -1,4 +1,3 @@
-import importlib
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, cast
 
@@ -8,20 +7,20 @@ from any_agent.frameworks.any_agent import AgentResult
 from any_agent.logging import logger
 from any_agent.tools import search_web, visit_webpage
 
-if TYPE_CHECKING:
-    from llama_index.core.agent.workflow.workflow_events import AgentOutput
-    from llama_index.core.llms import LLM
-
 try:
     from llama_index.core.agent.workflow import AgentWorkflow, ReActAgent
-    from llama_index.core.llms import LLM
+    from llama_index.llms.litellm import LiteLLM
 
+    DEFAULT_AGENT_TYPE = ReActAgent
+    DEFAULT_MODEL_TYPE = LiteLLM
     llama_index_available = True
 except ImportError:
     llama_index_available = False
 
 
-DEFAULT_MODEL_CLASS = "litellm.LiteLLM"
+if TYPE_CHECKING:
+    from llama_index.core.agent.workflow.workflow_events import AgentOutput
+    from llama_index.core.llms import LLM
 
 
 class LlamaIndexAgent(AnyAgent):
@@ -40,15 +39,9 @@ class LlamaIndexAgent(AnyAgent):
     def framework(self) -> AgentFramework:
         return AgentFramework.LLAMA_INDEX
 
-    def _get_model(self, agent_config: AgentConfig) -> LLM:
+    def _get_model(self, agent_config: AgentConfig) -> "LLM":
         """Get the model configuration for a llama_index agent."""
-        if not agent_config.model_type:
-            agent_config.model_type = DEFAULT_MODEL_CLASS
-        module, class_name = agent_config.model_type.rsplit(".")
-        model_type = getattr(
-            importlib.import_module(f"llama_index.llms.{module}"),
-            class_name,
-        )
+        model_type = agent_config.model_type or DEFAULT_MODEL_TYPE
         return cast(
             "LLM",
             model_type(
@@ -83,7 +76,8 @@ class LlamaIndexAgent(AnyAgent):
                     )
                     name = f"managed_agent_{n}"
                 managed_names.append(name)
-                managed_instance = ReActAgent(
+                agent_type = managed_agent.agent_type or DEFAULT_AGENT_TYPE
+                managed_instance = agent_type(
                     name=name,
                     description=managed_agent.description or "A managed agent",
                     system_prompt=managed_agent.instructions,
@@ -95,7 +89,8 @@ class LlamaIndexAgent(AnyAgent):
                 agents.append(managed_instance)
 
             main_tools, _ = await self._load_tools(self.config.tools)
-            main_agent = ReActAgent(
+            agent_type = self.config.agent_type or DEFAULT_AGENT_TYPE
+            main_agent = agent_type(
                 name=self.config.name,
                 description=self.config.description or "The main agent",
                 tools=main_tools,
@@ -106,12 +101,12 @@ class LlamaIndexAgent(AnyAgent):
             )
             agents.append(main_agent)
 
-            self._agent = AgentWorkflow(agents=agents, root_agent=main_agent.name)  # type: ignore[arg-type]
+            self._agent = AgentWorkflow(agents=agents, root_agent=main_agent.name)
 
         else:
             imported_tools, _ = await self._load_tools(self.config.tools)
-
-            self._agent = ReActAgent(
+            agent_type = self.config.agent_type or DEFAULT_AGENT_TYPE
+            self._agent = agent_type(
                 name=self.config.name,
                 tools=imported_tools,
                 description=self.config.description or "The main agent",

--- a/src/any_agent/frameworks/openai.py
+++ b/src/any_agent/frameworks/openai.py
@@ -8,10 +8,13 @@ try:
     from agents import (
         Agent,
         Handoff,
+        Model,
         ModelSettings,
         Runner,
     )
     from agents.extensions.models.litellm_model import LitellmModel
+
+    DEFAULT_MODEL_TYPE = LitellmModel
 
     agents_available = True
 except ImportError:
@@ -37,9 +40,10 @@ class OpenAIAgent(AnyAgent):
     def _get_model(
         self,
         agent_config: AgentConfig,
-    ) -> LitellmModel:
+    ) -> "Model":
         """Get the model configuration for an OpenAI agent."""
-        return LitellmModel(
+        model_type = agent_config.model_type or DEFAULT_MODEL_TYPE
+        return model_type(
             model=agent_config.model_id,
             base_url=agent_config.api_base,
             api_key=agent_config.api_key,

--- a/tests/integration/test_load_and_run_agent.py
+++ b/tests/integration/test_load_and_run_agent.py
@@ -14,9 +14,6 @@ from any_agent.tools import search_web
 def test_load_and_run_agent(agent_framework: AgentFramework, tmp_path: Path) -> None:
     kwargs = {}
 
-    if agent_framework is AgentFramework.SMOLAGENTS:
-        kwargs["agent_type"] = "ToolCallingAgent"
-
     kwargs["model_id"] = "gpt-4.1-nano"
     if "OPENAI_API_KEY" not in os.environ:
         pytest.skip(f"OPENAI_API_KEY needed for {agent_framework}")

--- a/tests/integration/test_load_and_run_multi_agent.py
+++ b/tests/integration/test_load_and_run_multi_agent.py
@@ -16,8 +16,6 @@ def test_load_and_run_multi_agent(
     agent_framework: AgentFramework, tmp_path: Path
 ) -> None:
     kwargs = {}
-    if agent_framework is AgentFramework.SMOLAGENTS:
-        kwargs["agent_type"] = "ToolCallingAgent"
 
     if agent_framework is AgentFramework.TINYAGENT:
         pytest.skip(

--- a/tests/unit/frameworks/test_agno.py
+++ b/tests/unit/frameworks/test_agno.py
@@ -15,7 +15,7 @@ def test_load_agno_default() -> None:
 
     with (
         patch("any_agent.frameworks.agno.Agent", mock_agent),
-        patch("any_agent.frameworks.agno.LiteLLM", mock_model),
+        patch("any_agent.frameworks.agno.DEFAULT_MODEL_TYPE", mock_model),
     ):
         AnyAgent.create(AgentFramework.AGNO, AgentConfig(model_id="gpt-4o"))
         mock_agent.assert_called_once_with(
@@ -40,7 +40,7 @@ def test_load_agno_multi_agent() -> None:
     with (
         patch("any_agent.frameworks.agno.Agent", mock_agent),
         patch("any_agent.frameworks.agno.Team", mock_team),
-        patch("any_agent.frameworks.agno.LiteLLM", mock_model),
+        patch("any_agent.frameworks.agno.DEFAULT_MODEL_TYPE", mock_model),
     ):
         AnyAgent.create(
             AgentFramework.AGNO,
@@ -81,7 +81,7 @@ def test_run_agno_custom_args() -> None:
 
     with (
         patch("any_agent.frameworks.agno.Agent", mock_agent),
-        patch("any_agent.frameworks.agno.LiteLLM", mock_model),
+        patch("any_agent.frameworks.agno.DEFAULT_MODEL_TYPE", mock_model),
     ):
         agent = AnyAgent.create(AgentFramework.AGNO, AgentConfig(model_id="gpt-4o"))
         agent.run("foo", retries=2)

--- a/tests/unit/frameworks/test_google.py
+++ b/tests/unit/frameworks/test_google.py
@@ -23,8 +23,8 @@ def test_load_google_default() -> None:
             return mock_function_tool
 
     with (
-        patch("any_agent.frameworks.google.Agent", mock_agent),
-        patch("any_agent.frameworks.google.LiteLlm", mock_model),
+        patch("any_agent.frameworks.google.LlmAgent", mock_agent),
+        patch("any_agent.frameworks.google.DEFAULT_MODEL_TYPE", mock_model),
         patch("google.adk.tools.FunctionTool", MockedFunctionTool),
     ):
         AnyAgent.create(AgentFramework.GOOGLE, AgentConfig(model_id="gpt-4o"))
@@ -51,8 +51,8 @@ def test_load_google_multiagent() -> None:
             return mock_function_tool
 
     with (
-        patch("any_agent.frameworks.google.Agent", mock_agent),
-        patch("any_agent.frameworks.google.LiteLlm", mock_model),
+        patch("any_agent.frameworks.google.LlmAgent", mock_agent),
+        patch("any_agent.frameworks.google.DEFAULT_MODEL_TYPE", mock_model),
         patch("any_agent.frameworks.google.AgentTool", mock_agent_tool),
         patch("google.adk.tools.FunctionTool", MockedFunctionTool),
     ):
@@ -115,9 +115,9 @@ def test_run_google_custom_args() -> None:
 
     run_config = RunConfig(max_llm_calls=10)
     with (
-        patch("any_agent.frameworks.google.Agent", mock_agent),
+        patch("any_agent.frameworks.google.LlmAgent", mock_agent),
         patch("any_agent.frameworks.google.InMemoryRunner", mock_runner),
-        patch("any_agent.frameworks.google.LiteLlm"),
+        patch("any_agent.frameworks.google.DEFAULT_MODEL_TYPE"),
         patch("google.adk.tools.FunctionTool"),
     ):
         agent = AnyAgent.create(AgentFramework.GOOGLE, AgentConfig(model_id="gpt-4o"))

--- a/tests/unit/frameworks/test_langchain.py
+++ b/tests/unit/frameworks/test_langchain.py
@@ -17,8 +17,8 @@ def test_load_langchain_agent_default() -> None:
     tool_mock = MagicMock()
 
     with (
-        patch("any_agent.frameworks.langchain.create_react_agent", create_mock),
-        patch("langchain_litellm.ChatLiteLLM", model_mock),
+        patch("any_agent.frameworks.langchain.DEFAULT_AGENT_TYPE", create_mock),
+        patch("any_agent.frameworks.langchain.DEFAULT_MODEL_TYPE", model_mock),
         patch("langchain_core.tools.tool", tool_mock),
     ):
         AnyAgent.create(AgentFramework.LANGCHAIN, AgentConfig(model_id="gpt-4o"))
@@ -52,9 +52,9 @@ def test_load_langchain_multiagent() -> None:
     tool_mock = MagicMock()
 
     with (
-        patch("any_agent.frameworks.langchain.create_react_agent", create_mock),
+        patch("any_agent.frameworks.langchain.DEFAULT_AGENT_TYPE", create_mock),
         patch("any_agent.frameworks.langchain.create_handoff_tool", handoff_mock),
-        patch("langchain_litellm.ChatLiteLLM", model_mock),
+        patch("any_agent.frameworks.langchain.DEFAULT_MODEL_TYPE", model_mock),
         patch("langchain_core.tools.tool", tool_mock),
     ):
         main_agent = AgentConfig(
@@ -102,8 +102,8 @@ def test_run_langchain_agent_custom_args() -> None:
     create_mock.return_value = agent_mock
 
     with (
-        patch("any_agent.frameworks.langchain.create_react_agent", create_mock),
-        patch("langchain_litellm.ChatLiteLLM"),
+        patch("any_agent.frameworks.langchain.DEFAULT_AGENT_TYPE", create_mock),
+        patch("any_agent.frameworks.langchain.DEFAULT_MODEL_TYPE"),
         patch("langchain_core.tools.tool"),
     ):
         agent = AnyAgent.create(

--- a/tests/unit/frameworks/test_llama_index.py
+++ b/tests/unit/frameworks/test_llama_index.py
@@ -18,8 +18,8 @@ def test_load_llama_index_agent_default() -> None:
     from llama_index.core.tools import FunctionTool
 
     with (
-        patch("any_agent.frameworks.llama_index.ReActAgent", create_mock),
-        patch("llama_index.llms.litellm.LiteLLM", model_mock),
+        patch("any_agent.frameworks.llama_index.DEFAULT_AGENT_TYPE", create_mock),
+        patch("any_agent.frameworks.llama_index.DEFAULT_MODEL_TYPE", model_mock),
         patch.object(FunctionTool, "from_defaults", tool_mock),
     ):
         AnyAgent.create(
@@ -48,7 +48,7 @@ def test_load_llama_index_agent_missing() -> None:
             AnyAgent.create(AgentFramework.LLAMA_INDEX, AgentConfig(model_id="gpt-4o"))
 
 
-def test_load_langchain_multiagent() -> None:
+def test_load_llama_index_multiagent() -> None:
     model_mock = MagicMock()
     create_mock = MagicMock()
     agent_mock = MagicMock()
@@ -57,9 +57,9 @@ def test_load_langchain_multiagent() -> None:
     from llama_index.core.tools import FunctionTool
 
     with (
-        patch("any_agent.frameworks.llama_index.ReActAgent", create_mock),
+        patch("any_agent.frameworks.llama_index.DEFAULT_AGENT_TYPE", create_mock),
         patch("any_agent.frameworks.llama_index.AgentWorkflow"),
-        patch("llama_index.llms.litellm.LiteLLM", model_mock),
+        patch("any_agent.frameworks.llama_index.DEFAULT_MODEL_TYPE", model_mock),
         patch.object(FunctionTool, "from_defaults", tool_mock),
     ):
         main_agent = AgentConfig(model_id="gpt-4.1-mini")
@@ -107,8 +107,8 @@ def test_run_llama_index_agent_custom_args() -> None:
     from llama_index.core.tools import FunctionTool
 
     with (
-        patch("any_agent.frameworks.llama_index.ReActAgent", create_mock),
-        patch("llama_index.llms.litellm.LiteLLM"),
+        patch("any_agent.frameworks.llama_index.DEFAULT_AGENT_TYPE", create_mock),
+        patch("any_agent.frameworks.llama_index.DEFAULT_MODEL_TYPE"),
         patch.object(FunctionTool, "from_defaults"),
     ):
         agent = AnyAgent.create(

--- a/tests/unit/frameworks/test_openai.py
+++ b/tests/unit/frameworks/test_openai.py
@@ -20,7 +20,7 @@ def test_load_openai_default() -> None:
     with (
         patch("any_agent.frameworks.openai.Agent", mock_agent),
         patch("agents.function_tool", mock_function_tool),
-        patch("any_agent.frameworks.openai.LitellmModel", mock_litellm_model),
+        patch("any_agent.frameworks.openai.DEFAULT_MODEL_TYPE", mock_litellm_model),
     ):
         AnyAgent.create(AgentFramework.OPENAI, AgentConfig(model_id="gpt-4o"))
 
@@ -45,7 +45,7 @@ def test_openai_with_api_base() -> None:
     with (
         patch("any_agent.frameworks.openai.Agent", mock_agent),
         patch(
-            "any_agent.frameworks.openai.LitellmModel",
+            "any_agent.frameworks.openai.DEFAULT_MODEL_TYPE",
             litllm_model_mock,
         ),
     ):
@@ -66,7 +66,7 @@ def test_openai_with_api_key() -> None:
     with (
         patch("any_agent.frameworks.openai.Agent", mock_agent),
         patch(
-            "any_agent.frameworks.openai.LitellmModel",
+            "any_agent.frameworks.openai.DEFAULT_MODEL_TYPE",
             litellm_model_mock,
         ),
     ):
@@ -92,7 +92,7 @@ def test_load_openai_with_mcp_server() -> None:
     with (
         patch("any_agent.frameworks.openai.Agent", mock_agent),
         patch("agents.function_tool", mock_function_tool),
-        patch("any_agent.frameworks.openai.LitellmModel", mock_litellm_model),
+        patch("any_agent.frameworks.openai.DEFAULT_MODEL_TYPE", mock_litellm_model),
         patch.object(AnyAgent, "_load_tools", mock_wrap_tools),
     ):
 
@@ -137,7 +137,7 @@ def test_load_openai_multiagent() -> None:
     with (
         patch("any_agent.frameworks.openai.Agent", mock_agent),
         patch("agents.function_tool", mock_function_tool),
-        patch("any_agent.frameworks.openai.LitellmModel", mock_litellm_model),
+        patch("any_agent.frameworks.openai.DEFAULT_MODEL_TYPE", mock_litellm_model),
     ):
         main_agent = AgentConfig(
             model_id="o3-mini",
@@ -230,7 +230,7 @@ def test_run_openai_with_custom_args() -> None:
         patch("any_agent.frameworks.openai.Runner", mock_runner),
         patch("any_agent.frameworks.openai.Agent", mock_agent),
         patch("agents.function_tool"),
-        patch("any_agent.frameworks.openai.LitellmModel"),
+        patch("any_agent.frameworks.openai.DEFAULT_MODEL_TYPE"),
     ):
         agent = AnyAgent.create(AgentFramework.OPENAI, AgentConfig(model_id="gpt-4o"))
         agent.run("foo", max_turns=30)

--- a/tests/unit/frameworks/test_smolagents.py
+++ b/tests/unit/frameworks/test_smolagents.py
@@ -3,10 +3,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from any_agent import AgentConfig, AgentFramework, AnyAgent
-from any_agent.frameworks.smolagents import (
-    DEFAULT_AGENT_TYPE,
-    DEFAULT_MODEL_CLASS,
-)
 from any_agent.tools import search_web, visit_webpage
 
 
@@ -16,8 +12,8 @@ def test_load_smolagent_default() -> None:
     mock_tool = MagicMock()
 
     with (
-        patch(f"smolagents.{DEFAULT_AGENT_TYPE}", mock_agent),
-        patch(f"smolagents.{DEFAULT_MODEL_CLASS}", mock_model),
+        patch("any_agent.frameworks.smolagents.DEFAULT_AGENT_TYPE", mock_agent),
+        patch("any_agent.frameworks.smolagents.DEFAULT_MODEL_TYPE", mock_model),
         patch("smolagents.tool", mock_tool),
     ):
         AnyAgent.create(
@@ -45,8 +41,8 @@ def test_load_smolagent_with_api_base() -> None:
     mock_tool = MagicMock()
 
     with (
-        patch(f"smolagents.{DEFAULT_AGENT_TYPE}", mock_agent),
-        patch(f"smolagents.{DEFAULT_MODEL_CLASS}", mock_model),
+        patch("any_agent.frameworks.smolagents.DEFAULT_AGENT_TYPE", mock_agent),
+        patch("any_agent.frameworks.smolagents.DEFAULT_MODEL_TYPE", mock_model),
         patch("smolagents.tool", mock_tool),
     ):
         AnyAgent.create(
@@ -82,8 +78,8 @@ def test_run_smolagent_custom_args() -> None:
     mock_agent = MagicMock()
     mock_agent.return_value = MagicMock()
     with (
-        patch(f"smolagents.{DEFAULT_AGENT_TYPE}", mock_agent),
-        patch(f"smolagents.{DEFAULT_MODEL_CLASS}"),
+        patch("any_agent.frameworks.smolagents.DEFAULT_AGENT_TYPE", mock_agent),
+        patch("any_agent.frameworks.smolagents.DEFAULT_MODEL_TYPE"),
         patch("smolagents.tool"),
     ):
         agent = AnyAgent.create(


### PR DESCRIPTION
Only add `agent_type` in frameworks where multiple classes are provided. Drop string imports.

- smolagents: Use ToolCallingAgent as default