### PR TITLE
Fix warning log in test_langchain

### DIFF
--- a/tests/unit/frameworks/test_langchain.py
+++ b/tests/unit/frameworks/test_langchain.py
@@ -99,6 +99,7 @@ def test_load_langchain_multiagent() -> None:
 def test_run_langchain_agent_custom_args() -> None:
     create_mock = MagicMock()
     agent_mock = AsyncMock()
+    agent_mock.ainvoke.return_value = MagicMock()
     create_mock.return_value = agent_mock
 
     with (


### PR DESCRIPTION
This is to fix

tests/unit/frameworks/test_langchain.py::test_run_langchain_agent_custom_args
  /Users/nbrake/scm/any-agent/src/any_agent/frameworks/langchain.py:138: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    if not result.get("messages"):
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.