### PR TITLE
Saving AgentTrace to a file is now the user/developers responsibility.

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -30,7 +30,7 @@ agent = AnyAgent.create(
         model_id="gpt-4o-mini",
         tools=[search_web]
     ),
-    tracing=TracingConfig(output_dir="traces")
+    tracing=TracingConfig(console=True, cost_info=False)
 )
 
 agent_trace = agent.run("How many seconds would it take for a leopard at full speed to run through Pont des Arts?")

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -155,7 +155,7 @@ Here's what that returned trace spans would look like, accessible via the attrib
 
 The AgentTrace object is a pydantic model and can be saved to disk via standard pydantic practices:
 
-```
+```python
 with open("output.json", "w", encoding="utf-8) as f:
   f.write(agent_trace.model_dump_json(indent=2))
 ```

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -2,10 +2,11 @@
 
 `any-agent` uses [`openinference`](https://github.com/Arize-ai/openinference) to generate
 standardized [OpenTelemetry](https://opentelemetry.io/) traces for any of the supported `Frameworks`.
+The trace is returned by calling the `agent.run` or `agent.run_async` functions.
 
 ## Example
 
-To configure tracing, pass a TracingConfig object [`TracingConfig`][any_agent.config.TracingConfig] when creating an agent.
+By default, tracing to console and cost tracking is enabled. To configure tracing, pass a TracingConfig object [`TracingConfig`][any_agent.config.TracingConfig] when creating an agent.
 
 ```python
 from any_agent import AgentConfig, AnyAgent, TracingConfig
@@ -22,10 +23,10 @@ agent = AnyAgent.create(
 agent_trace = agent.run("Which agent framework is the best?")
 ```
 
-### Outputs
+### Console Output
 
 Tracing will output standardized console output regardless of the
-framework used, and will also save the trace as a json file in the directory set by the TracingConfig object. The file path of the trace is stored in the Agent.trace_filepath member variable.
+framework used.
 
 ```console
 ──────────────────────────────────────────────────────────────────────────── LLM ─────────────────────────────────────────────────────────────────────────────
@@ -59,7 +60,9 @@ input: {'query': 'best agent framework 2023'}
 ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 ```
 
-In addition, an output JSON will be stored in the selected `output_dir`, which is `"traces"` by default:
+### Spans
+
+Here's what that returned trace spans would look like, accessible via the attribute `agent_trace.spans`:
 
 ```json
 [
@@ -145,4 +148,14 @@ In addition, an output JSON will be stored in the selected `output_dir`, which i
       "schema_url": ""
     }
   },
+```
+
+
+### Dumping to File
+
+The AgentTrace object is a pydantic model and can be saved to disk via standard pydantic practices:
+
+```
+with open("output.json", "w", encoding="utf-8) as f:
+  f.write(agent_trace.model_dump_json(indent=2))
 ```

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -156,6 +156,6 @@ Here's what that returned trace spans would look like, accessible via the attrib
 The AgentTrace object is a pydantic model and can be saved to disk via standard pydantic practices:
 
 ```python
-with open("output.json", "w", encoding="utf-8) as f:
+with open("output.json", "w", encoding="utf-8") as f:
   f.write(agent_trace.model_dump_json(indent=2))
 ```

--- a/src/any_agent/config.py
+++ b/src/any_agent/config.py
@@ -2,7 +2,7 @@ from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from enum import Enum, auto
 from typing import Any, Self
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class AgentFramework(str, Enum):
@@ -56,12 +56,6 @@ class TracingConfig(BaseModel):
     console: bool = True
     """Print to console."""
 
-    output_dir: str = "traces"
-    """Directory to save traces, if json is enabled"""
-
-    save: bool = True
-    """Save to json file."""
-
     cost_info: bool = True
     """whether json and console logs should include cost information"""
 
@@ -76,13 +70,6 @@ class TracingConfig(BaseModel):
 
     chain: str | None = None
     """Chain color in console logs"""
-
-    @model_validator(mode="after")
-    def validate_output_dir(self) -> Self:
-        if self.save and not self.output_dir:
-            msg = "output_dir must be set if `save` is enabled"
-            raise ValueError(msg)
-        return self
 
 
 MCPParams = MCPStdioParams | MCPSseParams

--- a/src/any_agent/tracing/trace.py
+++ b/src/any_agent/tracing/trace.py
@@ -139,7 +139,6 @@ class AgentTrace(BaseModel):
     """A trace that can be exported to JSON or printed to the console."""
 
     spans: list[AgentSpan] = Field(default_factory=list)
-    output_file: str | None = None
     final_output: str | None = None
 
     model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/tests/docs/test_all.py
+++ b/tests/docs/test_all.py
@@ -12,8 +12,8 @@ def test_files_all(fpath: pathlib.Path) -> None:
     mock_create = MagicMock(return_value=mock_agent)
 
     mock_create_async = AsyncMock()
-    # Mocking the sav_eval results function so that no actual file is created from running the code in evaluation.md
     with (
+        patch("builtins.open", new_callable=MagicMock),
         patch(
             "any_agent.evaluation.evaluation_runner.save_evaluation_results",
             return_value=None,

--- a/tests/integration/test_load_and_run_agent.py
+++ b/tests/integration/test_load_and_run_agent.py
@@ -74,10 +74,7 @@ def test_load_and_run_agent(agent_framework: AgentFramework, tmp_path: Path) -> 
         model_args=model_args,
         **kwargs,  # type: ignore[arg-type]
     )
-    traces = tmp_path / "traces"
-    agent = AnyAgent.create(
-        agent_framework, agent_config, tracing=TracingConfig(output_dir=str(traces))
-    )
+    agent = AnyAgent.create(agent_framework, agent_config, tracing=TracingConfig())
 
     try:
         agent_trace = agent.run(
@@ -92,10 +89,6 @@ def test_load_and_run_agent(agent_framework: AgentFramework, tmp_path: Path) -> 
         if is_tracing_supported(agent_framework):
             assert agent_trace.spans
             assert len(agent_trace.spans) > 0
-            assert traces.exists()
-            trace_files = [str(x) for x in traces.iterdir()]
-            assert agent_trace.output_file in trace_files
-            assert agent_framework.name in agent_trace.output_file
             cost_sum = agent_trace.get_total_cost()
             assert cost_sum.total_cost > 0
             assert cost_sum.total_cost < 1.00

--- a/tests/integration/test_load_and_run_multi_agent.py
+++ b/tests/integration/test_load_and_run_multi_agent.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 
 import pytest
 
@@ -13,9 +12,7 @@ from any_agent.tracing.trace import AgentTrace, is_tracing_supported
     os.environ.get("ANY_AGENT_INTEGRATION_TESTS", "FALSE").upper() != "TRUE",
     reason="Integration tests require `ANY_AGENT_INTEGRATION_TESTS=TRUE` env var",
 )
-def test_load_and_run_multi_agent(
-    agent_framework: AgentFramework, tmp_path: Path
-) -> None:
+def test_load_and_run_multi_agent(agent_framework: AgentFramework) -> None:
     kwargs = {}
 
     if agent_framework is AgentFramework.TINYAGENT:
@@ -56,14 +53,11 @@ def test_load_and_run_multi_agent(
         ),
     ]
 
-    traces = tmp_path / "traces"
     agent = AnyAgent.create(
         agent_framework=agent_framework,
         agent_config=main_agent,
         managed_agents=managed_agents,
-        tracing=TracingConfig(
-            output_dir=str(traces), console=False, save=True, cost_info=True
-        ),
+        tracing=TracingConfig(console=False, cost_info=True),
     )
     agent_trace = agent.run("Which agent framework is the best?")
 
@@ -72,10 +66,6 @@ def test_load_and_run_multi_agent(
     if is_tracing_supported(agent_framework):
         assert agent_trace.spans
         assert len(agent_trace.spans) > 0
-        assert traces.exists()
-        trace_files = [str(x) for x in traces.iterdir()]
-        assert agent_trace.output_file in trace_files
-        assert agent_framework.name in agent_trace.output_file
         cost_sum = agent_trace.get_total_cost()
         assert cost_sum.total_cost > 0
         assert cost_sum.total_cost < 1.00
@@ -90,10 +80,6 @@ def test_load_and_run_multi_agent(
         if is_tracing_supported(agent_framework):
             assert agent_trace.spans
             assert len(agent_trace.spans) > 0
-            assert traces.exists()
-            trace_files = [str(x) for x in traces.iterdir()]
-            assert agent_trace.output_file in trace_files
-            assert agent_framework.name in agent_trace.output_file
             cost_sum = agent_trace.get_total_cost()
             assert cost_sum.total_cost > 0
             assert cost_sum.total_cost < 1.00

--- a/tests/unit/tracing/test_unit_exporter.py
+++ b/tests/unit/tracing/test_unit_exporter.py
@@ -34,14 +34,6 @@ def test_rich_console_span_exporter_disable(llm_span: ReadableSpan):  # type: ig
         console_mock.return_value.rule.assert_not_called()
 
 
-def test_save_default(llm_span: ReadableSpan):  # type: ignore[no-untyped-def]
-    exporter = AnyAgentExporter(AgentFramework.LANGCHAIN, TracingConfig(console=False))
-    exporter.export([llm_span])
-    # Just to simulate more than 1 span
-    exporter.export([llm_span])
-    assert len(exporter.trace.spans) == 2
-
-
 def test_cost_info_default(llm_span: ReadableSpan):  # type: ignore[no-untyped-def]
     console_mock = MagicMock()
     with patch("any_agent.tracing.exporter.Console", console_mock):

--- a/tests/unit/tracing/test_unit_exporter.py
+++ b/tests/unit/tracing/test_unit_exporter.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from opentelemetry.sdk.trace import ReadableSpan
@@ -7,24 +6,19 @@ from any_agent.config import AgentFramework, TracingConfig
 from any_agent.tracing.exporter import AnyAgentExporter
 
 
-def test_exporter_initialization(
-    agent_framework: AgentFramework, tmp_path: Path
-) -> None:
+def test_exporter_initialization(agent_framework: AgentFramework) -> None:
     exporter = AnyAgentExporter(
         agent_framework=agent_framework,
-        tracing_config=TracingConfig(
-            output_dir=str(tmp_path / "traces"),
-        ),
+        tracing_config=TracingConfig(),
     )
 
-    assert (tmp_path / "traces").exists()
     assert exporter.console is not None
 
 
 def test_rich_console_span_exporter_default(llm_span: ReadableSpan):  # type: ignore[no-untyped-def]
     console_mock = MagicMock()
     with patch("any_agent.tracing.exporter.Console", console_mock):
-        exporter = AnyAgentExporter(AgentFramework.LANGCHAIN, TracingConfig(save=False))
+        exporter = AnyAgentExporter(AgentFramework.LANGCHAIN, TracingConfig())
         exporter.export([llm_span])
         console_mock.return_value.rule.assert_called()
 
@@ -34,23 +28,18 @@ def test_rich_console_span_exporter_disable(llm_span: ReadableSpan):  # type: ig
     with patch("any_agent.tracing.exporter.Console", console_mock):
         exporter = AnyAgentExporter(
             AgentFramework.LANGCHAIN,
-            TracingConfig(save=False, llm=None),
+            TracingConfig(llm=None),
         )
         exporter.export([llm_span])
         console_mock.return_value.rule.assert_not_called()
 
 
-def test_save_default(tmp_path, llm_span: ReadableSpan):  # type: ignore[no-untyped-def]
-    exporter = AnyAgentExporter(
-        AgentFramework.LANGCHAIN,
-        TracingConfig(output_dir=str(tmp_path), console=False, save=True),
-    )
+def test_save_default(llm_span: ReadableSpan):  # type: ignore[no-untyped-def]
+    exporter = AnyAgentExporter(AgentFramework.LANGCHAIN, TracingConfig(console=False))
     exporter.export([llm_span])
     # Just to simulate more than 1 span
     exporter.export([llm_span])
-    trace_files = [str(x) for x in tmp_path.iterdir()]
-    assert len(trace_files) == 1
-    assert exporter.trace.output_file in trace_files
+    assert len(exporter.trace.spans) == 2
 
 
 def test_cost_info_default(llm_span: ReadableSpan):  # type: ignore[no-untyped-def]
@@ -58,7 +47,9 @@ def test_cost_info_default(llm_span: ReadableSpan):  # type: ignore[no-untyped-d
     with patch("any_agent.tracing.exporter.Console", console_mock):
         exporter = AnyAgentExporter(
             AgentFramework.LANGCHAIN,
-            TracingConfig(console=False, save=False),
+            TracingConfig(
+                console=False,
+            ),
         )
         exporter.export([llm_span])
         attributes = exporter.trace.spans[0].attributes
@@ -74,7 +65,7 @@ def test_rich_console_cost_info_disabled(llm_span: ReadableSpan):  # type: ignor
     with patch("any_agent.tracing.exporter.Console", console_mock):
         exporter = AnyAgentExporter(
             AgentFramework.LANGCHAIN,
-            TracingConfig(save=False, console=False, cost_info=False),
+            TracingConfig(console=False, cost_info=False),
         )
         exporter.export([llm_span])
         attributes = exporter.trace.spans[0].attributes


### PR DESCRIPTION
Per our discussion, it is no longer the responsibility of any-agent to manage and save output files for an AgentTrace. the developer who calls `agent.run()` is now responsible to save it to a file if they want it.