### PR TITLE
fix(AgnoMCPConnection): Pass `include_tools=None` if no tools.

### DIFF
--- a/src/any_agent/tools/mcp/frameworks/agno.py
+++ b/src/any_agent/tools/mcp/frameworks/agno.py
@@ -44,7 +44,7 @@ class AgnoMCPStdioConnection(AgnoMCPConnection):
         server_params = f"{self.mcp_tool.command} {' '.join(self.mcp_tool.args)}"
         self._server = AgnoMCPTools(
             command=server_params,
-            include_tools=list(self.mcp_tool.tools or []),
+            include_tools=list(self.mcp_tool.tools) if self.mcp_tool.tools else None,
             env={**os.environ},
         )
         return await super().list_tools()
@@ -66,7 +66,7 @@ class AgnoMCPSseConnection(AgnoMCPConnection):
         await session.initialize()
         self._server = AgnoMCPTools(
             session=session,
-            include_tools=list(self.mcp_tool.tools or []),
+            include_tools=list(self.mcp_tool.tools) if self.mcp_tool.tools else None,
         )
         return await super().list_tools()
 

--- a/tests/unit/tools/mcp/conftest.py
+++ b/tests/unit/tools/mcp/conftest.py
@@ -78,6 +78,11 @@ def stdio_params(command: str, tools: Sequence[str]) -> MCPStdio:
 
 
 @pytest.fixture
+def stdio_params_no_tools(command: str) -> MCPStdio:
+    return MCPStdio(command=command, args=[])
+
+
+@pytest.fixture
 def mcp_tools(tools: Sequence[str]) -> list[MCPTool]:
     return [
         MCPTool(name=tool, inputSchema={"type": "string", "properties": {}})
@@ -125,4 +130,12 @@ def mcp_connection(tools: Sequence[Tool]) -> _MCPConnection[Any]:
     params=[lf("stdio_params"), lf("mcp_sse_params_with_tools")], ids=["STDIO", "SSE"]
 )
 def mcp_params(request: pytest.FixtureRequest) -> MCPParams:
+    return request.param  # type: ignore[no-any-return]
+
+
+@pytest.fixture(
+    params=[lf("stdio_params_no_tools"), lf("mcp_sse_params_no_tools")],
+    ids=["STDIO", "SSE"],
+)
+def mcp_params_no_tools(request: pytest.FixtureRequest) -> MCPParams:
     return request.param  # type: ignore[no-any-return]

--- a/tests/unit/tools/mcp/test_unit_agno_mcp.py
+++ b/tests/unit/tools/mcp/test_unit_agno_mcp.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 from agno.tools.mcp import MCPTools as AgnoMCPTools
 
-from any_agent.config import AgentFramework, MCPSse, Tool
+from any_agent.config import AgentFramework, MCPParams, MCPSse, Tool
 from any_agent.tools import _get_mcp_server
 
 
@@ -32,3 +32,19 @@ async def test_agno_mcp_sse_integration(
     session.initialize.assert_called_once()
 
     agno_mcp_tools.assert_called_once_with(session=session, include_tools=tools)  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures(
+    "enter_context_with_transport_and_session",
+)
+async def test_agno_mcp_no_tools(
+    mcp_params_no_tools: MCPParams,
+    agno_mcp_tools: AgnoMCPTools,
+) -> None:
+    """Regression test:"""
+    mcp_server = _get_mcp_server(mcp_params_no_tools, AgentFramework.AGNO)
+
+    await mcp_server._setup_tools()
+
+    assert agno_mcp_tools.call_args_list[0].kwargs["include_tools"] is None  # type: ignore[attr-defined]


### PR DESCRIPTION
Agno expects the argument to be None https://github.com/agno-agi/agno/blob/1bea45ea0f8801113ddd52c4626a616ef7043c5b/libs/agno/agno/tools/mcp.py#L198 otherwise no available tools are returned.