### PR TITLE
Explicitly ignore conflicting rules due to `extend-select = ["ALL"]`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,7 +168,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 # Ruff stuff:
 .ruff_cache/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,8 @@ ignore = [
   "FIX",
   "D100",  # We don't use module docstrings
   "D104",  # We don't use package docstrings
+  "D203",  # <- disable to resolve conflict with D211
+  "D213",  # <- disable to resolve conflict with D212
   "FBT",
   "COM",
   "ANN",


### PR DESCRIPTION
Using `extend-select = ["ALL"]` in the `pyproject.toml` means the ruff formatter evaluates all rules that aren't ignored. 

This PR adds two of them to the ignore list:

* D203: Blank line required between class declaration and docstring
* D213: Docstring cannot start on same line as """

Now running `pre-commit run --all-files` shouldn't error.

Closes: https://github.com/mozilla-ai/any-agent/issues/261