### PR TITLE
Add `[dependency-groups]` in `pyproject.toml`

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Install requirements
         run: |
-          uv sync --extra docs
+          uv sync --group docs
           uv pip install 'git+https://github.com/google/A2A#subdirectory=samples/python'
 
       - name: Build docs

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,7 +22,7 @@ jobs:
           activate-environment: true
 
       - name: Install pre-commit
-        run: uv sync --extra lint
+        run: uv sync --group lint
 
       # In case of considering adding caching, check the following PR first:
       # https://github.com/mozilla-ai/any-agent/pull/186

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install
         run: |
-          uv pip install -e '.[all,tests]'
+          uv sync --group tests --extra all
           uv pip install 'git+https://github.com/google/A2A#subdirectory=samples/python'
 
       - name: Run Documentation tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ We welcome all kinds of contributions, from improving customization, to extendin
 
 ### **Submit Pull Requests** 💻
 - Fork the repository and create a new branch for your changes.
-- Install [pre-commit](https://pre-commit.com/) to ensure the code is formatted and standardized correctly, by running `pip install pre-commit` and then `pre-commit install`.
+- Install [pre-commit](https://pre-commit.com/) to ensure the code is formatted and standardized correctly, by running `uv sync --group lint` and then `pre-commit install`.
 - Ensure your branch is up-to-date with the main branch before submitting the PR
 - Please follow the PR template, adding as much detail as possible, including how to test the changes
 
@@ -40,7 +40,7 @@ We welcome all kinds of contributions, from improving customization, to extendin
 
 **Testing**
 - Test changes locally to ensure functionality.
-- Install the package using development dependencies before testing: `pip install -e ".[dev,all]"; pytest -v tests`
+- Install the package using development dependencies before testing: `uv sync --group dev --extra all`
 - Integration tests need the following environment variables to be set:
   ```
   ANY_AGENT_INTEGRATION_TESTS=TRUE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ lint = [
   "pre-commit-uv==4.1.4",
 ]
 
+[dependency-groups]
 dev = [
   "any-agent[docs,tests,lint]",
   "pre-commit",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,21 +10,23 @@ requires-python = ">=3.11"
 dynamic = ["version"]
 dependencies = [
   "duckduckgo_search",
-  "tavily-python",
+  "evaluate",
   "fire",
   "litellm",
-  "mcp>=1.5.0",
   "markdownify",
+  "mcp>=1.5.0",
   "opentelemetry-exporter-otlp",
   "opentelemetry-sdk",
   "pydantic",
   "requests",
   "rich",
-  "evaluate",
-  "fire",
+  "tavily-python",
 ]
 
 [project.optional-dependencies]
+agno = [
+  "agno>=1.4.6",
+]
 
 google = [
   "google-adk>=0.3.0"
@@ -43,13 +45,8 @@ llama_index = [
   "llama-index",
   "llama-index-llms-litellm",
   "llama-index-tools-mcp",
+  "openinference-instrumentation-llama-index",
   "platformdirs>=4.3.7",
-  "openinference-instrumentation-llama-index"
-]
-
-smolagents = [
-  "smolagents[mcp]>=1.14.0",
-  "openinference-instrumentation-smolagents"
 ]
 
 openai = [
@@ -57,46 +54,22 @@ openai = [
   "openinference-instrumentation-openai-agents>=0.1.5"
 ]
 
-agno = [
-  "agno>=1.4.6",
+smolagents = [
+  "openinference-instrumentation-smolagents",
+  "smolagents[mcp]>=1.14.0",
 ]
 
 all = [
-  "any-agent[google,langchain,llama_index,smolagents,openai,agno,serving]",
-]
-
-docs = [
-  "mkdocs",
-  "mkdocs-material",
-  "mkdocstrings-python",
-  "mkdocs-include-markdown-plugin>=7.1.5",
-]
-
-tests = [
-  "pytest>=8,<9",
-  "pytest-sugar>=0.9.6",
-  "pytest-asyncio>=0.26.0",
-  "pytest-lazy-fixtures>=1.1.2",
-  "pytest-timeout>=2.4.0",
-  "debugpy>=1.8.13",
-  "mktestdocs>=0.2.4",
-]
-
-lint = [
-  "pre-commit==4.2.0",
-  "pre-commit-uv==4.1.4",
-]
-
-[dependency-groups]
-dev = [
-  "any-agent[docs,tests,lint]",
-  "pre-commit",
+  "any-agent[agno,google,langchain,llama_index,openai,smolagents]",
 ]
 
 [project.urls]
 Documentation = "https://mozilla-ai.github.io/any-agent/"
 Issues = "https://github.com/mozilla-ai/any-agent/issues"
 Source = "https://github.com/mozilla-ai/any-agent"
+
+[project.scripts]
+any-agent-evaluate = "any_agent.evaluation.cli:main"
 
 [tool.setuptools.package-data]
 "*" = ["py.typed"]
@@ -168,5 +141,40 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
 timeout = 300
 
-[project.scripts]
-any-agent-evaluate = "any_agent.evaluation.cli:main"
+
+[dependency-groups]
+dev = [
+  { include-group = "docs" },
+  { include-group = "lint" },
+  { include-group = "tests" },
+]
+
+docs = [
+  "mkdocs",
+  "mkdocs-material",
+  "mkdocstrings-python",
+  "mkdocs-include-markdown-plugin>=7.1.5",
+]
+
+lint = [
+  "pre-commit==4.2.0",
+  "pre-commit-uv==4.1.4",
+]
+
+tests = [
+  "pytest>=8,<9",
+  "pytest-sugar>=0.9.6",
+  "pytest-asyncio>=0.26.0",
+  "pytest-lazy-fixtures>=1.1.2",
+  "pytest-timeout>=2.4.0",
+  "debugpy>=1.8.13",
+  "mktestdocs>=0.2.4",
+]
+
+# For completeness, but 'uv sync --group dev' currently installs the others too.
+all = [
+  { include-group = "dev" },
+  { include-group = "docs" },
+  { include-group = "lint" },
+  { include-group = "tests" },
+]


### PR DESCRIPTION
This PR adds `[dependency-groups]` to the `pyproject.toml`, so tools like [`uv`](https://docs.astral.sh/uv/) can correctly install development dependencies when you run (for example):

```console
uv sync --group dev --extra all
```

See: https://peps.python.org/pep-0735/
See: https://packaging.python.org/en/latest/specifications/dependency-groups/

### Note

For some reason `pip` is not compatible with dependency groups despite the above and PEP0735. `dev` is a dependency group so this command doesn't install the `dev` group, just the 'all' optional extras:

```console
pip install -e ".[dev,all]"
```

You get a warning that there's no 'optional' (extra) group named `dev`:

```console
WARNING: any-agent 0.14.2.dev3+gbd66881 does not provide the extra 'dev'
```