### PR TITLE
chore(tests): Add pytest-xdist for parallel test execution

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,9 +38,9 @@ jobs:
       - name: Run Unit tests
         run: pytest -v tests/unit
 
-      - name: Run Integration tests
+      - name: Run Integration tests (parallel with xdist)
         if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' }}
         env:
           ANY_AGENT_INTEGRATION_TESTS: TRUE
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: pytest -v tests/integration
+        run: pytest -v tests/integration -n auto

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,4 +43,4 @@ jobs:
         env:
           ANY_AGENT_INTEGRATION_TESTS: TRUE
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: pytest -v tests/integration -n auto
+        run: pytest -v tests/integration -d --tx '4*popen//python=python'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,7 @@ tests = [
   "pytest-asyncio>=0.26.0",
   "pytest-lazy-fixtures>=1.1.2",
   "pytest-timeout>=2.4.0",
+  "pytest-xdist>=3.6.1",
   "debugpy>=1.8.13",
   "mktestdocs>=0.2.4",
 ]


### PR DESCRIPTION
- Updated `pyproject.toml` to include `pytest-xdist` as a testing dependency.
- Modified GitHub Actions workflow to run integration tests in parallel using `-n auto` for improved efficiency.