### PR TITLE
Pre-Commit should use local code for type stubs and package ver, not the last published any-agent

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,16 +27,28 @@ repos:
           - "--exit-non-zero-on-fix"
       - id: ruff-format
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.15.0"
+  - repo: local
+    # Thanks to https://jaredkhan.com/blog/mypy-pre-commit
+    # We do not use pre-commit/mirrors-mypy,
+    # as it is difficult to configure to run
+    # with the dependencies correctly installed.
     hooks:
       - id: mypy
+        name: mypy
+        entry: "./scripts/run-mypy.sh"
+        language: python
+        language_version: python3.12
         additional_dependencies:
+          - mypy==1.15.0
+          - pip
           - types-requests
           - types-pyyaml
-          - pytest
-          - google-adk==0.5.0 # until https://github.com/mozilla-ai/any-agent/issues/287 is resolved
-          - any-agent[dev, all]
+        types: [python]
+        # use require_serial so that script
+        # is only called once per commit
+        require_serial: true
+        # Print the number of files as a sanity-check
+        verbose: true
 
   - repo: https://github.com/codespell-project/codespell
     rev: "v2.4.1"

--- a/scripts/run-mypy.sh
+++ b/scripts/run-mypy.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Thank you to https://jaredkhan.com/blog/mypy-pre-commit for this super helpful script!
+# A script for running mypy, 
+# with all its dependencies installed.
+
+set -o errexit
+
+# Change directory to the project root directory.
+cd "$(dirname "$0")/.."
+
+# Install the dependencies into the mypy env.
+# Note that this can take seconds to run.
+# In my case, I need to use a custom index URL.
+# Avoid pip spending time quietly retrying since 
+# likely cause of failure is lack of VPN connection.
+python -m pip install -e '.[all]' --quiet
+
+# Run on all files, 
+# ignoring the paths passed to this script,
+# so as not to miss type errors.
+# My repo makes use of namespace packages.
+# Use the namespace-packages flag 
+# and specify the package to run on explicitly.
+# Note that we do not use --ignore-missing-imports, 
+# as this can give us false confidence in our results.
+python -m mypy --ignore-missing-imports src/


### PR DESCRIPTION
Pre-commit was pulling any-agent from pypi (not the local pyproject.toml), which meant that if you're working on new features with new package versions, there's this confusing conflict. 

This PR fixes that by making pre-commit use the local installed stubs.

Big shoutout to https://jaredkhan.com/blog/mypy-pre-commit, without it I would have been confused for much longer :) 