### PR TITLE
Run all tests even if only docs changed

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,15 +23,6 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v4
 
-      - name: Detect docs-only changes
-        id: docs_only
-        run: |
-          if git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -v '^docs/' | grep -q .; then
-            echo "docs_only=false" >> $GITHUB_OUTPUT
-          else
-            echo "docs_only=true" >> $GITHUB_OUTPUT
-          fi
-
       - name: Install the latest version of uv and set the python version to 3.11
         uses: astral-sh/setup-uv@v6
         with:
@@ -47,15 +38,13 @@ jobs:
         run: pytest -v tests/docs
 
       - name: Run Unit tests
-        if: steps.docs_only.outputs.docs_only == 'false'
         run: pytest -v tests/unit
 
       - name: Run Snapshot tests
-        if: steps.docs_only.outputs.docs_only == 'false'
         run: pytest -v tests/snapshots
 
       - name: Run Integration tests (parallel with xdist)
-        if: steps.docs_only.outputs.docs_only == 'false' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch')
+        if: steps.docs_only.outputs.docs_only == 'false' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
         env:
           ANY_AGENT_INTEGRATION_TESTS: TRUE
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,7 +44,7 @@ jobs:
         run: pytest -v tests/snapshots
 
       - name: Run Integration tests (parallel with xdist)
-        if: steps.docs_only.outputs.docs_only == 'false' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
         env:
           ANY_AGENT_INTEGRATION_TESTS: TRUE
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
Unfortunately the logic I added in https://github.com/mozilla-ai/any-agent/pull/312 to check whether just docs have changed means that manually triggering the workflow doesn't run all the tests :( 

Until we work on a better mechanism, better to run all tests when there have been changes to docs.