### PR TITLE
Pin Pydantic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
   "mcp>=1.5.0",
   "opentelemetry-exporter-otlp",
   "opentelemetry-sdk",
-  "pydantic",
+  "pydantic==2.11.4",
   "requests",
   "rich",
   "tavily-python",


### PR DESCRIPTION
Pydantic v2.11.5 broke our code: https://github.com/pydantic/pydantic/releases/tag/v2.11.5 

```
  return self.validator.validate_python(
            object,
            strict=strict,
            from_attributes=from_attributes,
            context=context,
            allow_partial=experimental_allow_partial,
            by_alias=by_alias,
            by_name=by_name,
        )
E       pydantic_core._pydantic_core.ValidationError: 33 validation errors for union[AgnoMCPServerStdio,AgnoMCPServerSse,GoogleMCPServerStdio,GoogleMCPServerSse,LangchainMCPServerStdio,LangchainMCPServerSse,LlamaIndexMCPServerStdio,LlamaIndexMCPServerSse,OpenAIMCPServerStdio,OpenAIMCPServerSse,SmolagentsMCPServerStdio,SmolagentsMCPServerSse,TinyAgentMCPServerStdio,TinyAgentMCPServerSse]
E       AgnoMCPServerStdio.framework
E         Input should be <AgentFramework.AGNO: 'agno'> [type=literal_error, input_value=<AgentFramework.SMOLAGENTS: 'smolagents'>, input_type=AgentFramework]
E           For further information visit https://errors.pydantic.dev/2.11/v/literal_error
E       AgnoMCPServerStdio.tools
E         Field required [type=missing, input_value={'mcp_tool': MCPStdio(com...OLAGENTS: 'smolagents'>}, input_type=dict]
E           For further information visit https://errors.pydantic.dev/2.11/v/missing
E       AgnoMCPServerSse.mcp_tool
E         Input should be a valid dictionary or instance of MCPSse [type=model_type, input_value=MCPStdio(command="print('...ssion_timeout_seconds=5), input_type=MCPStdio]
E           For further information visit https://errors.pydantic.dev/2.11/v/model_type
E       AgnoMCPServerSse.framework
E         Input should be <AgentFramework.AGNO: 'agno'> [type=literal_error, input_value=<AgentFramework.SMOLAGENTS: 'smolagents'>, input_type=AgentFramework]
E           For further information visit https://errors.pydantic.dev/2.11/v/literal_error
E       AgnoMCPServerSse.tools
E         Field required [type=missing, input_value={'mcp_tool': MCPStdio(com...OLAGENTS: 'smolagents'>}, input_type=dict]
E           For further information visit https://errors.pydantic.dev/2.11/v/missing
E       GoogleMCPServerStdio.framework
E         Input should be <AgentFramework.GOOGLE: 'google'> [type=literal_error, input_value=<AgentFramework.SMOLAGENTS: 'smolagents'>, input_type=AgentFramework]
E           For further information visit https://errors.pydantic.dev/2.11/v/literal_error
E       GoogleMCPServerStdio.tools
E         Field required [type=missing, input_value={'mcp_tool': MCPStdio(com...OLAGENTS: 'smolagents'>}, input_type=dict]
E           For further information visit https://errors.pydantic.dev/2.11/v/missing
E       GoogleMCPServerSse.mcp_tool
E         Input should be a valid dictionary or instance of MCPSse [type=model_type, input_value=MCPStdio(command="print('...ssion_timeout_seconds=5), input_type=MCPStdio]
E           For further information visit https://errors.pydantic.dev/2.11/v/model_type
E       GoogleMCPServerSse.framework
E         Input should be <AgentFramework.GOOGLE: 'google'> [type=literal_error, input_value=<AgentFramework.SMOLAGENTS: 'smolagents'>, input_type=AgentFramework]
E           For further information visit https://errors.pydantic.dev/2.11/v/literal_error
E       GoogleMCPServerSse.tools
E         Field required [type=missing, input_value={'mcp_tool': MCPStdio(com...OLAGENTS: 'smolagents'>}, input_type=dict]
E           For further information visit https://errors.pydantic.dev/2.11/v/missing
E       LangchainMCPServerStdio.framework
E         Input should be <AgentFramework.LANGCHAIN: 'langchain'> [type=literal_error, input_value=<AgentFramework.SMOLAGENTS: 'smolagents'>, input_type=AgentFramework]
E           For further information visit https://errors.pydantic.dev/2.11/v/literal_error
E       LangchainMCPServerStdio.tools
E         Field required [type=missing, input_value={'mcp_tool': MCPStdio(com...OLAGENTS: 'smolagents'>}, input_type=dict]
E           For further information visit https://errors.pydantic.dev/2.11/v/missing
E       LangchainMCPServerSse.mcp_tool
E         Input should be a valid dictionary or instance of MCPSse [type=model_type, input_value=MCPStdio(command="print('...ssion_timeout_seconds=5), input_type=MCPStdio]
E           For further information visit https://errors.pydantic.dev/2.11/v/model_type
E       LangchainMCPServerSse.framework
E         Input should be <AgentFramework.LANGCHAIN: 'langchain'> [type=literal_error, input_value=<AgentFramework.SMOLAGENTS: 'smolagents'>, input_type=AgentFramework]
E           For further information visit https://errors.pydantic.dev/2.11/v/literal_error
E       LangchainMCPServerSse.tools
E         Field required [type=missing, input_value={'mcp_tool': MCPStdio(com...OLAGENTS: 'smolagents'>}, input_type=dict]
E           For further information visit https://errors.pydantic.dev/2.11/v/missing
E       LlamaIndexMCPServerStdio.framework
E         Input should be <AgentFramework.LLAMA_INDEX: 'llama_index'> [type=literal_error, input_value=<AgentFramework.SMOLAGENTS: 'smolagents'>, input_type=AgentFramework]
E           For further information visit https://errors.pydantic.dev/2.11/v/literal_error
E       LlamaIndexMCPServerStdio.tools
E         Field required [type=missing, input_value={'mcp_tool': MCPStdio(com...OLAGENTS: 'smolagents'>}, input_type=dict]
E           For further information visit https://errors.pydantic.dev/2.11/v/missing
E       LlamaIndexMCPServerSse.mcp_tool
E         Input should be a valid dictionary or instance of MCPSse [type=model_type, input_value=MCPStdio(command="print('...ssion_timeout_seconds=5), input_type=MCPStdio]
E           For further information visit https://errors.pydantic.dev/2.11/v/model_type
E       LlamaIndexMCPServerSse.framework
E         Input should be <AgentFramework.LLAMA_INDEX: 'llama_index'> [type=literal_error, input_value=<AgentFramework.SMOLAGENTS: 'smolagents'>, input_type=AgentFramework]
E           For further information visit https://errors.pydantic.dev/2.11/v/literal_error
E       LlamaIndexMCPServerSse.tools
E         Field required [type=missing, input_value={'mcp_tool': MCPStdio(com...OLAGENTS: 'smolagents'>}, input_type=dict]
E           For further information visit https://errors.pydantic.dev/2.11/v/missing
E       OpenAIMCPServerStdio.framework
E         Input should be <AgentFramework.OPENAI: 'openai'> [type=literal_error, input_value=<AgentFramework.SMOLAGENTS: 'smolagents'>, input_type=AgentFramework]
E           For further information visit https://errors.pydantic.dev/2.11/v/literal_error
E       OpenAIMCPServerStdio.tools
E         Field required [type=missing, input_value={'mcp_tool': MCPStdio(com...OLAGENTS: 'smolagents'>}, input_type=dict]
E           For further information visit https://errors.pydantic.dev/2.11/v/missing
E       OpenAIMCPServerSse.mcp_tool
E         Input should be a valid dictionary or instance of MCPSse [type=model_type, input_value=MCPStdio(command="print('...ssion_timeout_seconds=5), input_type=MCPStdio]
E           For further information visit https://errors.pydantic.dev/2.11/v/model_type
E       OpenAIMCPServerSse.framework
E         Input should be <AgentFramework.OPENAI: 'openai'> [type=literal_error, input_value=<AgentFramework.SMOLAGENTS: 'smolagents'>, input_type=AgentFramework]
E           For further information visit https://errors.pydantic.dev/2.11/v/literal_error
E       OpenAIMCPServerSse.tools
E         Field required [type=missing, input_value={'mcp_tool': MCPStdio(com...OLAGENTS: 'smolagents'>}, input_type=dict]
E           For further information visit https://errors.pydantic.dev/2.11/v/missing
E       SmolagentsMCPServerStdio.tools
E         Field required [type=missing, input_value={'mcp_tool': MCPStdio(com...OLAGENTS: 'smolagents'>}, input_type=dict]
E           For further information visit https://errors.pydantic.dev/2.11/v/missing
E       SmolagentsMCPServerSse.mcp_tool
E         Input should be a valid dictionary or instance of MCPSse [type=model_type, input_value=MCPStdio(command="print('...ssion_timeout_seconds=5), input_type=MCPStdio]
E           For further information visit https://errors.pydantic.dev/2.11/v/model_type
E       SmolagentsMCPServerSse.tools
E         Field required [type=missing, input_value={'mcp_tool': MCPStdio(com...OLAGENTS: 'smolagents'>}, input_type=dict]
E           For further information visit https://errors.pydantic.dev/2.11/v/missing
E       TinyAgentMCPServerStdio.framework
E         Input should be <AgentFramework.TINYAGENT: 'tinyagent'> [type=literal_error, input_value=<AgentFramework.SMOLAGENTS: 'smolagents'>, input_type=AgentFramework]
E           For further information visit https://errors.pydantic.dev/2.11/v/literal_error
E       TinyAgentMCPServerStdio.tools
E         Field required [type=missing, input_value={'mcp_tool': MCPStdio(com...OLAGENTS: 'smolagents'>}, input_type=dict]
E           For further information visit https://errors.pydantic.dev/2.11/v/missing
E       TinyAgentMCPServerSse.mcp_tool
E         Input should be a valid dictionary or instance of MCPSse [type=model_type, input_value=MCPStdio(command="print('...ssion_timeout_seconds=5), input_type=MCPStdio]
E           For further information visit https://errors.pydantic.dev/2.11/v/model_type
E       TinyAgentMCPServerSse.framework
E         Input should be <AgentFramework.TINYAGENT: 'tinyagent'> [type=literal_error, input_value=<AgentFramework.SMOLAGENTS: 'smolagents'>, input_type=AgentFramework]
E           For further information visit https://errors.pydantic.dev/2.11/v/literal_error
E       TinyAgentMCPServerSse.tools
E         Field required [type=missing, input_value={'mcp_tool': MCPStdio(com...OLAGENTS: 'smolagents'>}, input_type=dict]
E           For further information visit https://errors.pydantic.dev/2.11/v/missing

.venv/lib/python3.13/site-packages/pydantic/type_adapter.py:421: ValidationError
```