### PR TITLE
Remove unnecessary span.end() calls in Agno, Smolagents, and TinyAgen…

### DIFF
--- a/src/any_agent/tracing/instrumentation/agno.py
+++ b/src/any_agent/tracing/instrumentation/agno.py
@@ -100,7 +100,6 @@ class _AgnoInstrumentor:
                 _set_llm_output(assistant_message, span)
 
                 span.set_status(StatusCode.OK)
-                span.end()
 
             return assistant_message, has_tool_calls
 
@@ -151,7 +150,6 @@ class _AgnoInstrumentor:
                         )
 
                     span.set_status(StatusCode.OK)
-                    span.end()
 
                 yield function_call_response
 

--- a/src/any_agent/tracing/instrumentation/smolagents.py
+++ b/src/any_agent/tracing/instrumentation/smolagents.py
@@ -100,7 +100,6 @@ class _SmolagentsInstrumentor:
                 _set_llm_output(response, span)
 
                 span.set_status(StatusCode.OK)
-                span.end()
 
                 return response
 
@@ -129,7 +128,6 @@ class _SmolagentsInstrumentor:
                         }
                     )
                 span.set_status(StatusCode.OK)
-                span.end()
 
                 return result
 

--- a/src/any_agent/tracing/instrumentation/tinyagent.py
+++ b/src/any_agent/tracing/instrumentation/tinyagent.py
@@ -95,7 +95,6 @@ class _TinyAgentInstrumentor:
                 _set_llm_output(response, span)
 
                 span.set_status(StatusCode.OK)
-                span.end()
 
                 return response
 
@@ -129,7 +128,6 @@ class _TinyAgentInstrumentor:
                 )
 
                 span.set_status(StatusCode.OK)
-                span.end()
 
                 return result
 


### PR DESCRIPTION
…t instrumentors for cleaner tracing.

the span is handled by the context manager which will automagically call span.end() when you leave the context.