### PR TITLE
_get_mcp_server fix

### DIFF
--- a/src/any_agent/tools/mcp/frameworks/__init__.py
+++ b/src/any_agent/tools/mcp/frameworks/__init__.py
@@ -22,7 +22,19 @@ MCPServer = (
 
 
 def _get_mcp_server(mcp_tool: MCPParams, agent_framework: AgentFramework) -> MCPServer:
-    return TypeAdapter[MCPServer](MCPServer).validate_python(
+    mapping = {
+        AgentFramework.GOOGLE: GoogleMCPServer,
+        AgentFramework.LANGCHAIN: LangchainMCPServer,
+        AgentFramework.LLAMA_INDEX: LlamaIndexMCPServer,
+        AgentFramework.OPENAI: OpenAIMCPServer,
+        AgentFramework.AGNO: AgnoMCPServer,
+        AgentFramework.SMOLAGENTS: SmolagentsMCPServer,
+        AgentFramework.TINYAGENT: TinyAgentMCPServer,
+    }
+    cls = mapping.get(agent_framework)
+    if cls is None:
+        raise ValueError(f"Unsupported agent framework: {agent_framework}")
+    return TypeAdapter[cls](cls).validate_python(
         {"mcp_tool": mcp_tool, "framework": agent_framework}
     )
 


### PR DESCRIPTION
#322
for me, even  pydantic 2.11.4 reports error, same as pydantic 2.11.5 or 2.11.3
```
Traceback (most recent call last):
  File "/Users/femtozheng/python-project/any-agent/src/any_agent/frameworks/any_agent.py", line 129, in create_async
    await agent._load_agent()
  File "/Users/femtozheng/python-project/any-agent/src/any_agent/frameworks/tinyagent.py", line 139, in _load_agent
    wrapped_tools, mcp_servers = await self._load_tools(self.config.tools)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/femtozheng/python-project/any-agent/src/any_agent/frameworks/any_agent.py", line 135, in _load_tools
    tools, mcp_servers = await _wrap_tools(tools, self.framework)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/femtozheng/python-project/any-agent/src/any_agent/tools/wrappers.py", line 136, in _wrap_tools
    mcp_server = _get_mcp_server(tool, agent_framework)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/femtozheng/python-project/any-agent/src/any_agent/tools/mcp/frameworks/__init__.py", line 25, in _get_mcp_server
    return TypeAdapter[MCPServer](MCPServer).validate_python(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/femtozheng/python-project/any-agent/venv/lib/python3.11/site-packages/pydantic/type_adapter.py", line 421, in validate_python
    return self.validator.validate_python(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/femtozheng/python-project/any-agent/venv/lib/python3.11/site-packages/pydantic/_internal/_mock_val_ser.py", line 100, in __getattr__
    raise PydanticUserError(self._error_message, code=self._code)
pydantic.errors.PydanticUserError: `TypeAdapter[any_agent.tools.mcp.frameworks.agno.AgnoMCPServerStdio | any_agent.tools.mcp.frameworks.agno.AgnoMCPServerSse | any_agent.tools.mcp.frameworks.google.GoogleMCPServerStdio | any_agent.tools.mcp.frameworks.google.GoogleMCPServerSse | any_agent.tools.mcp.frameworks.langchain.LangchainMCPServerStdio | any_agent.tools.mcp.frameworks.langchain.LangchainMCPServerSse | any_agent.tools.mcp.frameworks.llama_index.LlamaIndexMCPServerStdio | any_agent.tools.mcp.frameworks.llama_index.LlamaIndexMCPServerSse | any_agent.tools.mcp.frameworks.openai.OpenAIMCPServerStdio | any_agent.tools.mcp.frameworks.openai.OpenAIMCPServerSse | any_agent.tools.mcp.frameworks.smolagents.SmolagentsMCPServerStdio | any_agent.tools.mcp.frameworks.smolagents.SmolagentsMCPServerSse | any_agent.tools.mcp.frameworks.tinyagent.TinyAgentMCPServerStdio | any_agent.tools.mcp.frameworks.tinyagent.TinyAgentMCPServerSse]` is not fully defined; you should define `any_agent.tools.mcp.frameworks.agno.AgnoMCPServerStdio | any_agent.tools.mcp.frameworks.agno.AgnoMCPServerSse | any_agent.tools.mcp.frameworks.google.GoogleMCPServerStdio | any_agent.tools.mcp.frameworks.google.GoogleMCPServerSse | any_agent.tools.mcp.frameworks.langchain.LangchainMCPServerStdio | any_agent.tools.mcp.frameworks.langchain.LangchainMCPServerSse | any_agent.tools.mcp.frameworks.llama_index.LlamaIndexMCPServerStdio | any_agent.tools.mcp.frameworks.llama_index.LlamaIndexMCPServerSse | any_agent.tools.mcp.frameworks.openai.OpenAIMCPServerStdio | any_agent.tools.mcp.frameworks.openai.OpenAIMCPServerSse | any_agent.tools.mcp.frameworks.smolagents.SmolagentsMCPServerStdio | any_agent.tools.mcp.frameworks.smolagents.SmolagentsMCPServerSse | any_agent.tools.mcp.frameworks.tinyagent.TinyAgentMCPServerStdio | any_agent.tools.mcp.frameworks.tinyagent.TinyAgentMCPServerSse` and all referenced types, then call `.rebuild()` on the instance.

For further information visit https://errors.pydantic.dev/2.11/u/class-not-fully-defined
python-BaseException
```
```
return TypeAdapter[MCPServer](MCPServer).validate_python(
        {"mcp_tool": mcp_tool, "framework": agent_framework}
    )
``` 
is just too vague for pydantic
    
so I add a few more hints.    
