### PR TITLE
Fix to string

### DIFF
--- a/src/any_agent/tracing/instrumentation/smolagents.py
+++ b/src/any_agent/tracing/instrumentation/smolagents.py
@@ -118,7 +118,7 @@ class _SmolagentsInstrumentor:
                     }
                 )
 
-                result: AgentType | None = wrapped(*args, **kwargs)
+                result: AgentType | Any | None = wrapped(*args, **kwargs)
 
                 if result:
                     span.set_attributes(


### PR DESCRIPTION
```
                if result:
                    span.set_attributes(
                        {
                            "gen_ai.output":result.to_string(),
                            "gen_ai.output.type": "text",
                        }
                    )
```
  to_string() will throw error when using CodeAgent,(which result is just a str),
  so I change to "gen_ai.output": str(result)