### PR TITLE
Add end-of-file newline to JSON generated by `--update-trace-assets`.

### DIFF
--- a/tests/integration/test_load_and_run_agent.py
+++ b/tests/integration/test_load_and_run_agent.py
@@ -204,6 +204,7 @@ def test_load_and_run_agent(
             trace_path = Path(__file__).parent.parent / "assets" / agent_framework.name
             with open(f"{trace_path}_trace.json", "w", encoding="utf-8") as f:
                 f.write(agent_trace.model_dump_json(indent=2))
+                f.write("\n")
             html_output = agent._exporter.console.export_html(inline_styles=True)  # type: ignore[union-attr]
             with open(f"{trace_path}_trace.html", "w", encoding="utf-8") as f:
                 f.write(html_output.replace("<!DOCTYPE html>", ""))


### PR DESCRIPTION
Every time I updated the traces the pre-commit was updating the json because of the missing newline.