### PR TITLE
feat(mcp): Remove TypeAdapter

### DIFF
--- a/src/any_agent/tools/__init__.py
+++ b/src/any_agent/tools/__init__.py
@@ -1,13 +1,6 @@
 from .a2a_tool import a2a_query
 from .mcp import (
-    AgnoMCPServer,
-    GoogleMCPServer,
-    LangchainMCPServer,
-    LlamaIndexMCPServer,
     MCPServer,
-    OpenAIMCPServer,
-    SmolagentsMCPServer,
-    TinyAgentMCPServer,
     _get_mcp_server,
     _MCPConnection,
     _MCPServerBase,
@@ -21,14 +14,7 @@ from .user_interaction import (
 from .web_browsing import search_tavily, search_web, visit_webpage
 
 __all__ = [
-    "AgnoMCPServer",
-    "GoogleMCPServer",
-    "LangchainMCPServer",
-    "LlamaIndexMCPServer",
     "MCPServer",
-    "OpenAIMCPServer",
-    "SmolagentsMCPServer",
-    "TinyAgentMCPServer",
     "_MCPConnection",
     "_MCPServerBase",
     "_get_mcp_server",

--- a/src/any_agent/tools/mcp/__init__.py
+++ b/src/any_agent/tools/mcp/__init__.py
@@ -1,26 +1,12 @@
 from .frameworks import (
-    AgnoMCPServer,
-    GoogleMCPServer,
-    LangchainMCPServer,
-    LlamaIndexMCPServer,
     MCPServer,
-    OpenAIMCPServer,
-    SmolagentsMCPServer,
-    TinyAgentMCPServer,
     _get_mcp_server,
 )
 from .mcp_connection import _MCPConnection
 from .mcp_server import _MCPServerBase
 
 __all__ = [
-    "AgnoMCPServer",
-    "GoogleMCPServer",
-    "LangchainMCPServer",
-    "LlamaIndexMCPServer",
     "MCPServer",
-    "OpenAIMCPServer",
-    "SmolagentsMCPServer",
-    "TinyAgentMCPServer",
     "_MCPConnection",
     "_MCPServerBase",
     "_get_mcp_server",

--- a/src/any_agent/tools/mcp/frameworks/__init__.py
+++ b/src/any_agent/tools/mcp/frameworks/__init__.py
@@ -55,9 +55,7 @@ def _get_stdio_mcp_server(
     assert_never(agent_framework)
 
 
-def _get_sse_mcp_server(
-    mcp_tool: MCPSse, agent_framework: AgentFramework
-) -> MCPServer:
+def _get_sse_mcp_server(mcp_tool: MCPSse, agent_framework: AgentFramework) -> MCPServer:
     if agent_framework is AgentFramework.AGNO:
         from .agno import AgnoMCPServerSse
 
@@ -88,10 +86,11 @@ def _get_sse_mcp_server(
         return TinyAgentMCPServerSse(mcp_tool=mcp_tool)
     assert_never(agent_framework)
 
+
 def _get_mcp_server(mcp_tool: MCPParams, agent_framework: AgentFramework) -> MCPServer:
     if isinstance(mcp_tool, MCPStdio):
         return _get_stdio_mcp_server(mcp_tool, agent_framework)
-    elif isinstance(mcp_tool, MCPSse):
+    if isinstance(mcp_tool, MCPSse):
         return _get_sse_mcp_server(mcp_tool, agent_framework)
     assert_never(mcp_tool)
 

--- a/src/any_agent/tools/mcp/frameworks/__init__.py
+++ b/src/any_agent/tools/mcp/frameworks/__init__.py
@@ -1,6 +1,6 @@
-from pydantic import TypeAdapter
+from typing import assert_never
 
-from any_agent.config import AgentFramework, MCPParams
+from any_agent.config import AgentFramework, MCPParams, MCPSse, MCPStdio
 
 from .agno import AgnoMCPServer
 from .google import GoogleMCPServer
@@ -21,20 +21,82 @@ MCPServer = (
 )
 
 
+def _get_stdio_mcp_server(
+    mcp_tool: MCPStdio, agent_framework: AgentFramework
+) -> MCPServer:
+    if agent_framework is AgentFramework.AGNO:
+        from .agno import AgnoMCPServerStdio
+
+        return AgnoMCPServerStdio(mcp_tool=mcp_tool)
+    if agent_framework is AgentFramework.GOOGLE:
+        from .google import GoogleMCPServerStdio
+
+        return GoogleMCPServerStdio(mcp_tool=mcp_tool)
+    if agent_framework is AgentFramework.LANGCHAIN:
+        from .langchain import LangchainMCPServerStdio
+
+        return LangchainMCPServerStdio(mcp_tool=mcp_tool)
+    if agent_framework is AgentFramework.LLAMA_INDEX:
+        from .llama_index import LlamaIndexMCPServerStdio
+
+        return LlamaIndexMCPServerStdio(mcp_tool=mcp_tool)
+    if agent_framework is AgentFramework.OPENAI:
+        from .openai import OpenAIMCPServerStdio
+
+        return OpenAIMCPServerStdio(mcp_tool=mcp_tool)
+    if agent_framework is AgentFramework.SMOLAGENTS:
+        from .smolagents import SmolagentsMCPServerStdio
+
+        return SmolagentsMCPServerStdio(mcp_tool=mcp_tool)
+    if agent_framework is AgentFramework.TINYAGENT:
+        from .tinyagent import TinyAgentMCPServerStdio
+
+        return TinyAgentMCPServerStdio(mcp_tool=mcp_tool)
+    assert_never(agent_framework)
+
+
+def _get_sse_mcp_server(
+    mcp_tool: MCPSse, agent_framework: AgentFramework
+) -> MCPServer:
+    if agent_framework is AgentFramework.AGNO:
+        from .agno import AgnoMCPServerSse
+
+        return AgnoMCPServerSse(mcp_tool=mcp_tool)
+    if agent_framework is AgentFramework.GOOGLE:
+        from .google import GoogleMCPServerSse
+
+        return GoogleMCPServerSse(mcp_tool=mcp_tool)
+    if agent_framework is AgentFramework.LANGCHAIN:
+        from .langchain import LangchainMCPServerSse
+
+        return LangchainMCPServerSse(mcp_tool=mcp_tool)
+    if agent_framework is AgentFramework.LLAMA_INDEX:
+        from .llama_index import LlamaIndexMCPServerSse
+
+        return LlamaIndexMCPServerSse(mcp_tool=mcp_tool)
+    if agent_framework is AgentFramework.OPENAI:
+        from .openai import OpenAIMCPServerSse
+
+        return OpenAIMCPServerSse(mcp_tool=mcp_tool)
+    if agent_framework is AgentFramework.SMOLAGENTS:
+        from .smolagents import SmolagentsMCPServerSse
+
+        return SmolagentsMCPServerSse(mcp_tool=mcp_tool)
+    if agent_framework is AgentFramework.TINYAGENT:
+        from .tinyagent import TinyAgentMCPServerSse
+
+        return TinyAgentMCPServerSse(mcp_tool=mcp_tool)
+    assert_never(agent_framework)
+
 def _get_mcp_server(mcp_tool: MCPParams, agent_framework: AgentFramework) -> MCPServer:
-    return TypeAdapter[MCPServer](MCPServer).validate_python(
-        {"mcp_tool": mcp_tool, "framework": agent_framework}
-    )
+    if isinstance(mcp_tool, MCPStdio):
+        return _get_stdio_mcp_server(mcp_tool, agent_framework)
+    elif isinstance(mcp_tool, MCPSse):
+        return _get_sse_mcp_server(mcp_tool, agent_framework)
+    assert_never(mcp_tool)
 
 
 __all__ = [
-    "AgnoMCPServer",
-    "GoogleMCPServer",
-    "LangchainMCPServer",
-    "LlamaIndexMCPServer",
     "MCPServer",
-    "OpenAIMCPServer",
-    "SmolagentsMCPServer",
-    "TinyAgentMCPServer",
     "_get_mcp_server",
 ]


### PR DESCRIPTION
 Enhance MCP server initialization with dynamic handling for various agent frameworks

- Introduced `_get_stdio_mcp_server` and `_get_sse_mcp_server` functions to streamline MCP server creation based on the agent framework.
- Updated `_get_mcp_server` to utilize the new functions for better organization and clarity.
- Added support for additional agent frameworks in the MCP server initialization process.