### PR TITLE
test: Skip tests for specific agent frameworks due to known issues

### DIFF
--- a/tests/integration/test_load_and_run_multi_agent_a2a_tool.py
+++ b/tests/integration/test_load_and_run_multi_agent_a2a_tool.py
@@ -34,6 +34,17 @@ async def test_load_and_run_multi_agent(
 
     Note that there is an issue when using Google ADK: https://github.com/google/adk-python/pull/566
     """
+    if agent_framework in [
+        AgentFramework.GOOGLE,
+        AgentFramework.TINYAGENT,
+        AgentFramework.SMOLAGENTS,
+        AgentFramework.AGNO,
+        AgentFramework.OPENAI,
+        AgentFramework.LLAMA_INDEX,
+    ]:
+        pytest.skip(
+            "https://github.com/mozilla-ai/any-agent/issues/357 tracks fixing so these tests can be re-enabled"
+        )
     kwargs = {}
 
     kwargs["model_id"] = "gpt-4.1-nano"


### PR DESCRIPTION
- Added a conditional skip for tests when using Google, TinyAgent, SmolAgents, Agno, OpenAI, and Llama Index frameworks.
- This change addresses issue #357, allowing for smoother test execution while we work on a fix.