### PR TITLE
Remove dependency on hf `evaluate` library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ requires-python = ">=3.11"
 dynamic = ["version"]
 dependencies = [
   "duckduckgo_search",
-  "evaluate",
   "fire",
   "litellm",
   "markdownify",

--- a/src/any_agent/evaluation/evaluate.py
+++ b/src/any_agent/evaluation/evaluate.py
@@ -1,7 +1,7 @@
 from any_agent.evaluation.evaluation_case import EvaluationCase
 from any_agent.evaluation.evaluators import (
     evaluate_checkpoint,
-    evaluate_qa_squad,
+    evaluate_final_output,
 )
 from any_agent.evaluation.schemas import TraceEvaluationResult
 from any_agent.logging import logger
@@ -19,7 +19,7 @@ def evaluate(
     )
 
     if evaluation_case.ground_truth and trace.final_output:
-        ground_truth_result = evaluate_qa_squad(
+        ground_truth_result = evaluate_final_output(
             final_output=trace.final_output,
             ground_truth_answer=evaluation_case.ground_truth,
         )

--- a/tests/unit/evaluation/test_evaluate.py
+++ b/tests/unit/evaluation/test_evaluate.py
@@ -32,7 +32,7 @@ def test_evaluate_runs_all_evaluators(
             "any_agent.evaluation.evaluate.evaluate_checkpoint",
             mock_checkpoint_evaluate,
         ),
-        patch("any_agent.evaluation.evaluate.evaluate_qa_squad", mock_qa_evaluate),
+        patch("any_agent.evaluation.evaluate.evaluate_final_output", mock_qa_evaluate),
         patch("any_agent.evaluation.evaluators._construct_evidence"),
     ):
         evaluate(
@@ -73,7 +73,7 @@ def test_evaluate_when_no_final_output(
             "any_agent.evaluation.evaluate.evaluate_checkpoint",
             mock_checkpoint_evaluate,
         ),
-        patch("any_agent.evaluation.evaluate.evaluate_qa_squad", mock_qa_evaluate),
+        patch("any_agent.evaluation.evaluate.evaluate_final_output", mock_qa_evaluate),
         patch("any_agent.evaluation.evaluators._construct_evidence"),
     ):
         evaluate(


### PR DESCRIPTION
- Removed the `evaluate` dependency from `pyproject.toml`.
- Renamed `evaluate_qa_squad` to `evaluate_final_output` for clarity and updated its implementation to use F1 scoring for evaluation.
- Adjusted tests to reflect the new evaluation function name.

This change enhances the evaluation process by providing a more robust scoring mechanism while keeping the code clean and maintainable!