### PR TITLE
feat(mcp): Enhance client session timeout handling across multiple fr…

### DIFF
--- a/src/any_agent/tools/mcp/frameworks/llama_index.py
+++ b/src/any_agent/tools/mcp/frameworks/llama_index.py
@@ -45,10 +45,14 @@ class LlamaIndexMCPStdioConnection(LlamaIndexMCPConnection):
 
     async def list_tools(self) -> list["LlamaIndexFunctionTool"]:
         """List tools from the MCP server."""
+        kwargs = {}
+        if self.mcp_tool.client_session_timeout_seconds:
+            kwargs["timeout"] = self.mcp_tool.client_session_timeout_seconds
         self._client = LlamaIndexMCPClient(
             command_or_url=self.mcp_tool.command,
             args=list(self.mcp_tool.args),
             env=self.mcp_tool.env,
+            **kwargs,  # type: ignore[arg-type]
         )
         return await super().list_tools()
 
@@ -58,7 +62,13 @@ class LlamaIndexMCPSseConnection(LlamaIndexMCPConnection):
 
     async def list_tools(self) -> list["LlamaIndexFunctionTool"]:
         """List tools from the MCP server."""
-        self._client = LlamaIndexMCPClient(command_or_url=self.mcp_tool.url)
+        kwargs = {}
+        if self.mcp_tool.client_session_timeout_seconds:
+            kwargs["timeout"] = self.mcp_tool.client_session_timeout_seconds
+        self._client = LlamaIndexMCPClient(
+            command_or_url=self.mcp_tool.url,
+            **kwargs,  # type: ignore[arg-type]
+        )
         return await super().list_tools()
 
 

--- a/src/any_agent/tools/mcp/frameworks/openai.py
+++ b/src/any_agent/tools/mcp/frameworks/openai.py
@@ -67,6 +67,7 @@ class OpenAIMCPStdioConnection(OpenAIMCPConnection):
         self._server = OpenAIInternalMCPServerStdio(
             name="OpenAI MCP Server",
             params=params,
+            client_session_timeout_seconds=self.mcp_tool.client_session_timeout_seconds,
         )
         return await super().list_tools()
 
@@ -79,7 +80,9 @@ class OpenAIMCPSseConnection(OpenAIMCPConnection):
         params = OpenAIInternalMCPServerSseParams(url=self.mcp_tool.url)
 
         self._server = OpenAIInternalMCPServerSse(
-            name="OpenAI MCP Server", params=params
+            name="OpenAI MCP Server",
+            params=params,
+            client_session_timeout_seconds=self.mcp_tool.client_session_timeout_seconds,
         )
 
         return await super().list_tools()

--- a/src/any_agent/tools/mcp/frameworks/tinyagent.py
+++ b/src/any_agent/tools/mcp/frameworks/tinyagent.py
@@ -130,9 +130,13 @@ class TinyAgentMCPSseConnection(TinyAgentMCPConnection):
 
     async def list_tools(self) -> list["MCPTool"]:
         """List tools from the MCP server."""
+        kwargs = {}
+        if self.mcp_tool.client_session_timeout_seconds:
+            kwargs["sse_read_timeout"] = self.mcp_tool.client_session_timeout_seconds
         self._client = sse_client(
             url=self.mcp_tool.url,
             headers=dict(self.mcp_tool.headers or {}),
+            **kwargs,  # type: ignore[arg-type]
         )
 
         return await super().list_tools()

--- a/tests/unit/tools/mcp/test_unit_langchain_mcp.py
+++ b/tests/unit/tools/mcp/test_unit_langchain_mcp.py
@@ -59,3 +59,74 @@ async def test_langchain_mcp_env() -> None:
     ):
         await mcp_server._setup_tools()
         assert mocked_class.call_args_list[0][0][0].env == {"FOO": "BAR"}
+
+
+@pytest.mark.asyncio
+async def test_langchain_client_session_timeout_passed():
+    """Test that client_session_timeout_seconds parameter is properly passed to LangChain ClientSession (STDIO and SSE)."""
+    custom_timeout = 15.0
+    stdio_params = MCPStdio(
+        command="echo",
+        args=["test"],
+        client_session_timeout_seconds=custom_timeout,
+    )
+    sse_params = MCPSse(
+        url="http://localhost:8000",
+        client_session_timeout_seconds=custom_timeout,
+    )
+    # STDIO
+    server = _get_mcp_server(stdio_params, AgentFramework.LANGCHAIN)
+    with patch(
+        "any_agent.tools.mcp.frameworks.langchain.ClientSession"
+    ) as mock_session:
+        mock_session_instance = AsyncMock()
+        mock_session_instance.__aenter__ = AsyncMock(return_value=mock_session_instance)
+        mock_session_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_session_instance.initialize = AsyncMock()
+        mock_session.return_value = mock_session_instance
+        with patch(
+            "any_agent.tools.mcp.frameworks.langchain.load_mcp_tools"
+        ) as mock_load_tools:
+            mock_load_tools.return_value = []
+            with patch(
+                "any_agent.tools.mcp.frameworks.langchain.stdio_client"
+            ) as mock_client:
+                mock_client.return_value.__aenter__ = AsyncMock(
+                    return_value=(MagicMock(), MagicMock())
+                )
+                mock_client.return_value.__aexit__ = AsyncMock(return_value=None)
+                await server._setup_tools()
+                mock_session.assert_called_once()
+                call_args = mock_session.call_args
+                assert (
+                    call_args.kwargs["read_timeout_seconds"].total_seconds()
+                    == custom_timeout
+                )
+    # SSE
+    server = _get_mcp_server(sse_params, AgentFramework.LANGCHAIN)
+    with patch(
+        "any_agent.tools.mcp.frameworks.langchain.ClientSession"
+    ) as mock_session:
+        mock_session_instance = AsyncMock()
+        mock_session_instance.__aenter__ = AsyncMock(return_value=mock_session_instance)
+        mock_session_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_session_instance.initialize = AsyncMock()
+        mock_session.return_value = mock_session_instance
+        with patch(
+            "any_agent.tools.mcp.frameworks.langchain.load_mcp_tools"
+        ) as mock_load_tools:
+            mock_load_tools.return_value = []
+            with patch(
+                "any_agent.tools.mcp.frameworks.langchain.sse_client"
+            ) as mock_client:
+                mock_client.return_value.__aenter__ = AsyncMock(
+                    return_value=(MagicMock(), MagicMock())
+                )
+                mock_client.return_value.__aexit__ = AsyncMock(return_value=None)
+                await server._setup_tools()
+                mock_session.assert_called_once()
+                call_args = mock_session.call_args
+                assert (
+                    call_args.kwargs["read_timeout_seconds"].total_seconds()
+                    == custom_timeout
+                )


### PR DESCRIPTION
…ameworks

This update introduces a consistent approach to passing `client_session_timeout_seconds` to various MCP connection classes, including Agno, Langchain, LlamaIndex, and OpenAI. The timeout is now properly integrated into the respective client sessions for both STDIO and SSE connections, ensuring better control over session timeouts. Unit tests have been added to verify the correct behavior across these frameworks.