### PR TITLE
refactor: Rename `_main_agent_tools` to `_tools`

### DIFF
--- a/src/any_agent/frameworks/agno.py
+++ b/src/any_agent/frameworks/agno.py
@@ -63,7 +63,7 @@ class AgnoAgent(AnyAgent):
 
         tools, _ = await self._load_tools(self.config.tools)
 
-        self._main_agent_tools = self._unpack_tools(tools)
+        self._tools = self._unpack_tools(tools)
         self._agent = Agent(
             name=self.config.name,
             instructions=self.config.instructions,

--- a/src/any_agent/frameworks/any_agent.py
+++ b/src/any_agent/frameworks/any_agent.py
@@ -45,7 +45,7 @@ class AnyAgent(ABC):
         self.config = config
 
         self._mcp_servers: list[_MCPServerBase[Any]] = []
-        self._main_agent_tools: list[Any] = []
+        self._tools: list[Any] = []
 
         # Tracing is enabled by default
         self._tracing_config: TracingConfig = tracing or TracingConfig()

--- a/src/any_agent/frameworks/google.py
+++ b/src/any_agent/frameworks/google.py
@@ -55,7 +55,7 @@ class GoogleAgent(AnyAgent):
 
         agent_type = self.config.agent_type or LlmAgent
 
-        self._main_agent_tools = tools
+        self._tools = tools
         self._agent = agent_type(
             name=self.config.name,
             instruction=self.config.instructions or "",

--- a/src/any_agent/frameworks/langchain.py
+++ b/src/any_agent/frameworks/langchain.py
@@ -17,8 +17,6 @@ except ImportError:
     langchain_available = False
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-
     from langchain_core.language_models import LanguageModelLike
     from langchain_core.messages.base import BaseMessage
     from langgraph.graph.graph import CompiledGraph
@@ -34,7 +32,6 @@ class LangchainAgent(AnyAgent):
     ):
         super().__init__(config, tracing)
         self._agent: CompiledGraph | None = None
-        self._tools: Sequence[Any] = []
 
     @property
     def framework(self) -> AgentFramework:
@@ -62,7 +59,7 @@ class LangchainAgent(AnyAgent):
 
         imported_tools, _ = await self._load_tools(self.config.tools)
 
-        self._main_agent_tools = imported_tools
+        self._tools = imported_tools
         agent_type = self.config.agent_type or DEFAULT_AGENT_TYPE
         self._agent = agent_type(
             name=self.config.name,
@@ -71,9 +68,6 @@ class LangchainAgent(AnyAgent):
             prompt=self.config.instructions,
             **self.config.agent_args or {},
         )
-        # Langgraph doesn't let you easily access what tools are loaded from the CompiledGraph,
-        # so we'll store a list of them in this class
-        self._tools = imported_tools
 
     async def _run_async(self, prompt: str, **kwargs: Any) -> str:
         if not self._agent:

--- a/src/any_agent/frameworks/llama_index.py
+++ b/src/any_agent/frameworks/llama_index.py
@@ -57,7 +57,7 @@ class LlamaIndexAgent(AnyAgent):
 
         imported_tools, _ = await self._load_tools(self.config.tools)
         agent_type = self.config.agent_type or DEFAULT_AGENT_TYPE
-        self._main_agent_tools = imported_tools
+        self._tools = imported_tools
         self._agent = agent_type(
             name=self.config.name,
             tools=imported_tools,

--- a/src/any_agent/frameworks/openai.py
+++ b/src/any_agent/frameworks/openai.py
@@ -67,7 +67,7 @@ class OpenAIAgent(AnyAgent):
         if self.config.model_args:
             kwargs_["model_settings"] = ModelSettings(**self.config.model_args)
 
-        self._main_agent_tools = tools
+        self._tools = tools
         self._agent = Agent(
             name=self.config.name,
             instructions=self.config.instructions,

--- a/src/any_agent/frameworks/smolagents.py
+++ b/src/any_agent/frameworks/smolagents.py
@@ -55,7 +55,7 @@ class SmolagentsAgent(AnyAgent):
 
         main_agent_type = self.config.agent_type or DEFAULT_AGENT_TYPE
 
-        self._main_agent_tools = tools
+        self._tools = tools
         self._agent = main_agent_type(
             name=self.config.name,
             model=self._get_model(self.config),

--- a/src/any_agent/frameworks/tinyagent.py
+++ b/src/any_agent/frameworks/tinyagent.py
@@ -120,7 +120,7 @@ class TinyAgent(AnyAgent):
             mcp_servers  # Store servers so that they don't get garbage collected
         )
 
-        self._main_agent_tools = wrapped_tools
+        self._tools = wrapped_tools
 
         for tool in wrapped_tools:
             tool_name = tool.__name__

--- a/src/any_agent/serving/agent_card.py
+++ b/src/any_agent/serving/agent_card.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 def _get_agent_card(agent: AnyAgent, serving_config: ServingConfig) -> AgentCard:
     skills = []
-    for tool in agent._main_agent_tools:
+    for tool in agent._tools:
         if hasattr(tool, "name"):
             tool_name = tool.name
             tool_description = tool.description

--- a/tests/unit/serving/test_agent_card.py
+++ b/tests/unit/serving/test_agent_card.py
@@ -19,7 +19,7 @@ def test_get_agent_card(agent_framework: AgentFramework) -> None:
     agent = MagicMock()
     agent.config = AgentConfig(model_id="foo", description="test agent")
     agent.framework = agent_framework
-    agent._main_agent_tools = [WRAPPERS[agent_framework](search_web)]
+    agent._tools = [WRAPPERS[agent_framework](search_web)]
     agent_card = _get_agent_card(agent, ServingConfig())
     assert agent_card.name == "any_agent"
     assert agent_card.description == "test agent"
@@ -44,9 +44,9 @@ async def test_get_agent_card_with_mcp(  # type: ignore[no-untyped-def]
     server = _get_mcp_server(MCPSse(url=echo_sse_server["url"]), agent_framework)
     await server._setup_tools()
     if agent_framework is AgentFramework.AGNO:
-        agent._main_agent_tools = list(server.tools[0].functions.values())  # type: ignore[union-attr]
+        agent._tools = list(server.tools[0].functions.values())  # type: ignore[union-attr]
     else:
-        agent._main_agent_tools = server.tools
+        agent._tools = server.tools
 
     agent_card = _get_agent_card(agent, ServingConfig())
     assert agent_card.name == "any_agent"


### PR DESCRIPTION
Now that we don't use `managed_agents`, the `main_agent` naming is uneccessarily confusing imo