### PR TITLE
Add sync version of a2a tool

### DIFF
--- a/src/any_agent/tools/__init__.py
+++ b/src/any_agent/tools/__init__.py
@@ -1,4 +1,4 @@
-from .a2a import a2a_tool
+from .a2a import a2a_tool, a2a_tool_sync
 from .mcp import (
     MCPServer,
     _get_mcp_server,
@@ -19,6 +19,7 @@ __all__ = [
     "_MCPServerBase",
     "_get_mcp_server",
     "a2a_tool",
+    "a2a_tool_sync",
     "ask_user_verification",
     "search_tavily",
     "search_web",

--- a/src/any_agent/tools/a2a.py
+++ b/src/any_agent/tools/a2a.py
@@ -1,5 +1,6 @@
 # adapted from https://github.com/google/a2a-python/blob/main/examples/helloworld/test_client.py
 
+import asyncio
 import re
 from collections.abc import Callable, Coroutine
 from contextlib import suppress
@@ -28,7 +29,7 @@ with suppress(ImportError):
 async def a2a_tool(
     url: str, toolname: str | None = None, http_kwargs: dict[str, Any] | None = None
 ) -> Callable[[str], Coroutine[Any, Any, str]]:
-    """Perform a query using A2A to another agent.
+    """Perform a query using A2A to another agent (async function).
 
     Args:
         url (str): The url in which the A2A agent is located.
@@ -85,3 +86,24 @@ async def a2a_tool(
             The result from the A2A agent, encoded in json.
     """
     return _send_query
+
+
+def a2a_tool_sync(
+    url: str, toolname: str | None = None, http_kwargs: dict[str, Any] | None = None
+) -> Callable[[str], Coroutine[Any, Any, str]]:
+    """Perform a query using A2A to another agent (sync function).
+    Note that the result is still an async function.
+
+    Args:
+        url (str): The url in which the A2A agent is located.
+        toolname (str): The name for the created tool. Defaults to `call_{agent name in card}`.
+            Leading and trailing whitespace are removed. Whitespace in the middle is replaced by `_`.
+        http_kwargs (dict): Additional kwargs to pass to the httpx client.
+
+    Returns:
+        An async `Callable` that takes a query and returns the agent response.
+
+    """
+    return asyncio.get_event_loop().run_until_complete(
+        a2a_tool(url, toolname, http_kwargs)
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from textwrap import dedent
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
 from litellm.types.utils import ModelResponse
 
@@ -180,3 +181,15 @@ def build_tree(items: list[AgentSpan]) -> AgentSpan:
             else:
                 traces[None] = trace
     return traces[None]
+
+
+def probe(url: str) -> bool:
+    """Check that the URL returns something but doesn't time out"""
+    try:
+        with httpx.Client() as client:
+            client.get(url, timeout=1)
+            return True
+    except httpx.TimeoutException:
+        return False
+    except httpx.ConnectError:
+        return False


### PR DESCRIPTION
Provides a sync version of a2a tool. Note that the returned tool is still async. This may require further changes, since some frameworks cannot handle async functions as tools.

Closes #343 