### PR TITLE
408 A2A agentskills should be configurable

### DIFF
--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -8,6 +8,6 @@
 
 ::: any_agent.config.MCPSse
 
-::: any_agent.config.ServingConfig
+::: any_agent.serving.config.A2AServingConfig
 
 ::: any_agent.config.AgentFramework

--- a/docs/cookbook/a2a_as_tool.ipynb
+++ b/docs/cookbook/a2a_as_tool.ipynb
@@ -79,7 +79,8 @@
    "outputs": [],
    "source": [
     "from any_agent import AgentConfig, AnyAgent\n",
-    "from any_agent.config import MCPStdio, ServingConfig, TracingConfig\n",
+    "from any_agent.config import MCPStdio, TracingConfig\n",
+    "from any_agent.serving import A2AServingConfig\n",
     "\n",
     "# This MCP Tool relies upon uvx https://docs.astral.sh/uv/getting-started/installation/\n",
     "time_tool = MCPStdio(\n",
@@ -101,7 +102,7 @@
     "    tracing=TracingConfig(console=False),\n",
     ")\n",
     "(time_task, time_server) = await time.serve_async(\n",
-    "    ServingConfig(port=5000, endpoint=\"/time\")\n",
+    "    A2AServingConfig(port=5000, endpoint=\"/time\")\n",
     ")\n",
     "\n",
     "\n",
@@ -116,7 +117,7 @@
     "    tracing=TracingConfig(console=False),\n",
     ")\n",
     "(weather_task, weather_server) = await weather_expert.serve_async(\n",
-    "    ServingConfig(port=5001, endpoint=\"/location_recommender\")\n",
+    "    A2AServingConfig(port=5001, endpoint=\"/location_recommender\")\n",
     ")"
    ]
   },

--- a/docs/cookbook/serve_a2a.ipynb
+++ b/docs/cookbook/serve_a2a.ipynb
@@ -80,7 +80,8 @@
    "outputs": [],
    "source": [
     "from any_agent import AgentConfig, AnyAgent\n",
-    "from any_agent.config import MCPStdio, ServingConfig, TracingConfig\n",
+    "from any_agent.config import MCPStdio, TracingConfig\n",
+    "from any_agent.serving import A2AServingConfig\n",
     "\n",
     "# This MCP Tool relies upon uvx https://docs.astral.sh/uv/getting-started/installation/\n",
     "time_tool = MCPStdio(\n",
@@ -100,7 +101,7 @@
     "    ),\n",
     "    tracing=TracingConfig(console=False),\n",
     ")\n",
-    "(time_task, time_server) = await time.serve_async(ServingConfig(port=5000))"
+    "(time_task, time_server) = await time.serve_async(A2AServingConfig(port=5000))"
    ]
   },
   {

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -22,7 +22,7 @@ For illustrative purposes, we are going to define 2 separate scripts, each defin
     ```python
     # google_expert.py
     from any_agent import AgentConfig, AnyAgent
-    from any_agent.serving import ServingConfig
+    from any_agent.serving import A2AServingConfig
     from any_agent.tools import search_web
 
     agent = AnyAgent.create(
@@ -43,13 +43,13 @@ For illustrative purposes, we are going to define 2 separate scripts, each defin
     ```python
     # openai_expert.py
     from any_agent import AgentConfig, AnyAgent
-    from any_agent.serving.config import ServingConfig
+    from any_agent.serving import A2AServingConfig
     from any_agent.tools import search_web
 
     agent = AnyAgent.create(
         "openai",
         AgentConfig(
-            name="openai-expert",
+            name="openai_expert",
             model_id="gpt-4.1-nano",
             instructions="You can answer questions about the OpenAI Agents SDK but nothing else.",
             description="An agent that can answer questions specifically about the OpenAI Agents SDK.",
@@ -114,6 +114,37 @@ You will see that the first agent answered the question, but the second agent di
 This is because the question was about Google ADK,
 but the agent was told it could only answer questions about the OpenAI Agents SDK.
 
+## Advanced Configuration
+
+### Custom Skills
+
+By default, an agent's skills are automatically inferred from its tools. However, you can explicitly define skills for more control over the agent card:
+
+```python
+from a2a.types import AgentSkill
+from any_agent.serving import A2AServingConfig
+
+# Define custom skills
+custom_skills = [
+    AgentSkill(
+        id="web-search",
+        name="search_web",
+        description="Search the web for current information",
+        tags=["search", "web", "information"]
+    ),
+    AgentSkill(
+        id="data-analysis",
+        name="analyze_data",
+        description="Analyze datasets and provide insights",
+        tags=["analysis", "data", "insights"]
+    )
+]
+
+config = A2AServingConfig(
+    port=8080,
+    skills=custom_skills
+)
+```
 
 ## More Examples
 

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -10,7 +10,7 @@ the protocol, as explaining it is out of the scope of this page.
 
 In order to use A2A serving, you must first install the 'a2a' extra: `pip install 'any-agent[a2a]'`
 
-You can configure and serve an agent using the [`ServingConfig`][any_agent.config.ServingConfig] and the [`AnyAgent.serve`][any_agent.AnyAgent.serve] or [`AnyAgent.serve_async`][any_agent.AnyAgent.serve_async] method.
+You can configure and serve an agent using the [`A2AServingConfig`][any_agent.serving.A2AServingConfig] and the [`AnyAgent.serve`][any_agent.AnyAgent.serve] or [`AnyAgent.serve_async`][any_agent.AnyAgent.serve_async] method.
 
 ## Example
 

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -22,7 +22,7 @@ For illustrative purposes, we are going to define 2 separate scripts, each defin
     ```python
     # google_expert.py
     from any_agent import AgentConfig, AnyAgent
-    from any_agent.config import ServingConfig
+    from any_agent.serving import ServingConfig
     from any_agent.tools import search_web
 
     agent = AnyAgent.create(
@@ -35,7 +35,7 @@ For illustrative purposes, we are going to define 2 separate scripts, each defin
         )
     )
 
-    agent.serve(ServingConfig(port=5001))
+    agent.serve(A2AServingConfig(port=5001))
     ```
 
 === "OpenAI Expert"
@@ -43,7 +43,7 @@ For illustrative purposes, we are going to define 2 separate scripts, each defin
     ```python
     # openai_expert.py
     from any_agent import AgentConfig, AnyAgent
-    from any_agent.config import ServingConfig
+    from any_agent.serving.config import ServingConfig
     from any_agent.tools import search_web
 
     agent = AnyAgent.create(
@@ -57,7 +57,7 @@ For illustrative purposes, we are going to define 2 separate scripts, each defin
         )
     )
 
-    agent.serve(ServingConfig(port=5002))
+    agent.serve(A2AServingConfig(port=5002))
     ```
 
 We can then run each of the scripts in a separate terminal and leave them running in the background.

--- a/src/any_agent/config.py
+++ b/src/any_agent/config.py
@@ -83,39 +83,6 @@ class MCPSse(BaseModel):
     model_config = ConfigDict(frozen=True)
 
 
-class ServingConfig(BaseModel):
-    """Base configuration for serving an agent.
-
-    This abstract base class defines the common interface and validation
-    for serving agents over different protocols. It cannot be instantiated
-    directly - use concrete implementations like A2AServingConfig.
-
-    Note:
-        This is an abstract base class. Use A2AServingConfig or other
-        concrete implementations instead of instantiating this directly.
-
-    """
-
-    model_config = ConfigDict(extra="forbid")
-
-    host: str = "localhost"
-    """Will be passed as argument to `uvicorn.run`."""
-
-    port: int = 5000
-    """Will be passed as argument to `uvicorn.run`."""
-
-    endpoint: str = "/"
-    """Will be pass as argument to `Starlette().add_route`"""
-
-    log_level: str = "warning"
-    """Will be passed as argument to the `uvicorn` server."""
-
-    type: str
-    """The type of serving config (e.g. "a2a")"""
-
-    version: str = "0.1.0"
-
-
 class TracingConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 

--- a/src/any_agent/config.py
+++ b/src/any_agent/config.py
@@ -1,4 +1,3 @@
-from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from enum import StrEnum, auto
 from typing import Any, Self
@@ -84,11 +83,17 @@ class MCPSse(BaseModel):
     model_config = ConfigDict(frozen=True)
 
 
-class ServingConfig(BaseModel, ABC):
+class ServingConfig(BaseModel):
     """Base configuration for serving an agent.
 
-    This is an abstract base class that should not be instantiated directly.
-    Use one of the concrete implementations like A2AServingConfig instead.
+    This abstract base class defines the common interface and validation
+    for serving agents over different protocols. It cannot be instantiated
+    directly - use concrete implementations like A2AServingConfig.
+
+    Note:
+        This is an abstract base class. Use A2AServingConfig or other
+        concrete implementations instead of instantiating this directly.
+
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -105,14 +110,10 @@ class ServingConfig(BaseModel, ABC):
     log_level: str = "warning"
     """Will be passed as argument to the `uvicorn` server."""
 
+    type: str
+    """The type of serving config (e.g. "a2a")"""
+
     version: str = "0.1.0"
-
-    @abstractmethod
-    def get_config_type(self) -> str:
-        """Abstract method that must be implemented by concrete serving config classes.
-
-        This ensures that ServingConfig cannot be instantiated directly.
-        """
 
 
 class TracingConfig(BaseModel):

--- a/src/any_agent/config.py
+++ b/src/any_agent/config.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from enum import StrEnum, auto
 from typing import Any, Self
@@ -83,10 +84,11 @@ class MCPSse(BaseModel):
     model_config = ConfigDict(frozen=True)
 
 
-class ServingConfig(BaseModel):
-    """Configuration for serving an agent using the Agent2Agent Protocol (A2A).
+class ServingConfig(BaseModel, ABC):
+    """Base configuration for serving an agent.
 
-    We use the example `A2ASever` from https://github.com/google/A2A/tree/main/samples/python.
+    This is an abstract base class that should not be instantiated directly.
+    Use one of the concrete implementations like A2AServingConfig instead.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -104,6 +106,13 @@ class ServingConfig(BaseModel):
     """Will be passed as argument to the `uvicorn` server."""
 
     version: str = "0.1.0"
+
+    @abstractmethod
+    def get_config_type(self) -> str:
+        """Abstract method that must be implemented by concrete serving config classes.
+
+        This ensures that ServingConfig cannot be instantiated directly.
+        """
 
 
 class TracingConfig(BaseModel):

--- a/src/any_agent/frameworks/any_agent.py
+++ b/src/any_agent/frameworks/any_agent.py
@@ -181,10 +181,13 @@ class AnyAgent(ABC):
             ImportError: If the `serving` dependencies are not installed.
 
         """
-        from any_agent.serving import _get_a2a_app, serve_a2a
+        from any_agent.serving import A2AServingConfig, _get_a2a_app, serve_a2a
 
         if serving_config is None:
-            serving_config = ServingConfig()
+            serving_config = A2AServingConfig()
+        if not isinstance(serving_config, A2AServingConfig):
+            msg = "serving_config must be an instance of A2AServingConfig"
+            raise ValueError(msg)
         app = _get_a2a_app(self, serving_config=serving_config)
 
         serve_a2a(
@@ -207,10 +210,13 @@ class AnyAgent(ABC):
             ImportError: If the `serving` dependencies are not installed.
 
         """
-        from any_agent.serving import _get_a2a_app, serve_a2a_async
+        from any_agent.serving import A2AServingConfig, _get_a2a_app, serve_a2a_async
 
         if serving_config is None:
-            serving_config = ServingConfig()
+            serving_config = A2AServingConfig()
+        if not isinstance(serving_config, A2AServingConfig):
+            msg = "serving_config must be an instance of A2AServingConfig"
+            raise ValueError(msg)
         app = _get_a2a_app(self, serving_config=serving_config)
 
         return await serve_a2a_async(

--- a/src/any_agent/frameworks/any_agent.py
+++ b/src/any_agent/frameworks/any_agent.py
@@ -10,7 +10,6 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from any_agent.config import (
     AgentConfig,
     AgentFramework,
-    ServingConfig,
     Tool,
     TracingConfig,
 )
@@ -27,6 +26,7 @@ if TYPE_CHECKING:
 
     import uvicorn
 
+    from any_agent.serving.config import A2AServingConfig
     from any_agent.tools.mcp.mcp_server import _MCPServerBase
     from any_agent.tracing.agent_trace import AgentTrace
 
@@ -171,7 +171,7 @@ class AnyAgent(ABC):
         trace.final_output = final_output
         return trace
 
-    def serve(self, serving_config: ServingConfig | None = None) -> None:
+    def serve(self, serving_config: A2AServingConfig | None = None) -> None:
         """Serve this agent using the protocol defined in the serving_config.
 
         Args:
@@ -182,9 +182,9 @@ class AnyAgent(ABC):
             ImportError: If the `serving` dependencies are not installed.
 
         Example:
-            >>> agent = AnyAgent.create("tinyagent", AgentConfig(...))
-            >>> config = A2AServingConfig(port=8080, endpoint="/my-agent")
-            >>> agent.serve(config)
+            agent = AnyAgent.create("tinyagent", AgentConfig(...))
+            config = A2AServingConfig(port=8080, endpoint="/my-agent")
+            agent.serve(config)
 
         """
         from any_agent.serving import A2AServingConfig, _get_a2a_app, serve_a2a
@@ -192,13 +192,6 @@ class AnyAgent(ABC):
         if serving_config is None:
             serving_config = A2AServingConfig()
 
-        if not isinstance(serving_config, A2AServingConfig):
-            msg = (
-                f"serving_config must be an instance of A2AServingConfig, "
-                f"got {serving_config.type}. "
-                f"Currently only A2A serving is supported."
-            )
-            raise ValueError(msg)
         app = _get_a2a_app(self, serving_config=serving_config)
 
         serve_a2a(
@@ -210,7 +203,7 @@ class AnyAgent(ABC):
         )
 
     async def serve_async(
-        self, serving_config: ServingConfig | None = None
+        self, serving_config: A2AServingConfig | None = None
     ) -> tuple[asyncio.Task[Any], uvicorn.Server]:
         """Serve this agent asynchronously using the protocol defined in the serving_config.
 

--- a/src/any_agent/serving/__init__.py
+++ b/src/any_agent/serving/__init__.py
@@ -1,8 +1,9 @@
 try:
+    from .config import A2AServingConfig
     from .server import _get_a2a_app, serve_a2a, serve_a2a_async
 except ImportError as e:
     msg = "You need to `pip install 'any-agent[a2a]'` to use this method."
     raise ImportError(msg) from e
 
 
-__all__ = ["_get_a2a_app", "serve_a2a", "serve_a2a_async"]
+__all__ = ["A2AServingConfig", "_get_a2a_app", "serve_a2a", "serve_a2a_async"]

--- a/src/any_agent/serving/agent_card.py
+++ b/src/any_agent/serving/agent_card.py
@@ -9,29 +9,31 @@ from any_agent import AgentFramework
 
 if TYPE_CHECKING:
     from any_agent import AnyAgent
-    from any_agent.config import ServingConfig
+    from any_agent.serving.config import A2AServingConfig
 
 
-def _get_agent_card(agent: AnyAgent, serving_config: ServingConfig) -> AgentCard:
-    skills = []
-    for tool in agent._tools:
-        if hasattr(tool, "name"):
-            tool_name = tool.name
-            tool_description = tool.description
-        elif agent.framework is AgentFramework.LLAMA_INDEX:
-            tool_name = tool.metadata.name
-            tool_description = tool.metadata.description
-        else:
-            tool_name = tool.__name__
-            tool_description = inspect.getdoc(tool)
-        skills.append(
-            AgentSkill(
-                id=f"{agent.config.name}-{tool_name}",
-                name=tool_name,
-                description=tool_description,
-                tags=[],
+def _get_agent_card(agent: AnyAgent, serving_config: A2AServingConfig) -> AgentCard:
+    skills = serving_config.skills
+    if skills is None:
+        skills = []
+        for tool in agent._tools:
+            if hasattr(tool, "name"):
+                tool_name = tool.name
+                tool_description = tool.description
+            elif agent.framework is AgentFramework.LLAMA_INDEX:
+                tool_name = tool.metadata.name
+                tool_description = tool.metadata.description
+            else:
+                tool_name = tool.__name__
+                tool_description = inspect.getdoc(tool)
+            skills.append(
+                AgentSkill(
+                    id=f"{agent.config.name}-{tool_name}",
+                    name=tool_name,
+                    description=tool_description,
+                    tags=[],
+                )
             )
-        )
     if agent.config.description is None:
         msg = "Agent description is not set. Please set the `description` field in the `AgentConfig`."
         raise ValueError(msg)

--- a/src/any_agent/serving/config.py
+++ b/src/any_agent/serving/config.py
@@ -1,9 +1,8 @@
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
+
+from a2a.types import AgentSkill
 
 from any_agent.config import ServingConfig
-
-if TYPE_CHECKING:
-    from a2a.types import AgentSkill
 
 
 class A2AServingConfig(ServingConfig):
@@ -24,7 +23,7 @@ class A2AServingConfig(ServingConfig):
 
     """
 
-    skills: list["AgentSkill"] | None = None
+    skills: list[AgentSkill] | None = None
     """List of skills to be used by the agent.
 
     If not provided, the skills will be inferred from the tools.

--- a/src/any_agent/serving/config.py
+++ b/src/any_agent/serving/config.py
@@ -1,15 +1,28 @@
-from typing import Literal
-
-from a2a.types import AgentSkill
+from typing import TYPE_CHECKING, Literal
 
 from any_agent.config import ServingConfig
 
+if TYPE_CHECKING:
+    from a2a.types import AgentSkill
+
 
 class A2AServingConfig(ServingConfig):
-    """Configuration for serving an agent using the Agent2Agent Protocol (A2A)."""
+    """Configuration for serving an agent using the Agent2Agent Protocol (A2A).
 
-    type: Literal["a2a"] = "a2a"
-    """Type discriminator for A2A serving configuration."""
+    Example:
+        >>> config = A2AServingConfig(
+        ...     port=8080,
+        ...     endpoint="/my-agent",
+        ...     skills=[
+        ...         AgentSkill(
+        ...             id="search",
+        ...             name="web_search",
+        ...             description="Search the web for information"
+        ...         )
+        ...     ]
+        ... )
+
+    """
 
     skills: list["AgentSkill"] | None = None
     """List of skills to be used by the agent.
@@ -17,6 +30,4 @@ class A2AServingConfig(ServingConfig):
     If not provided, the skills will be inferred from the tools.
     """
 
-    def get_config_type(self) -> str:
-        """Implementation of abstract method from ServingConfig."""
-        return self.type
+    type: Literal["a2a"] = "a2a"

--- a/src/any_agent/serving/config.py
+++ b/src/any_agent/serving/config.py
@@ -1,27 +1,38 @@
-from typing import Literal
-
 from a2a.types import AgentSkill
+from pydantic import BaseModel, ConfigDict
 
-from any_agent.config import ServingConfig
 
-
-class A2AServingConfig(ServingConfig):
+class A2AServingConfig(BaseModel):
     """Configuration for serving an agent using the Agent2Agent Protocol (A2A).
 
     Example:
-        >>> config = A2AServingConfig(
-        ...     port=8080,
-        ...     endpoint="/my-agent",
-        ...     skills=[
-        ...         AgentSkill(
-        ...             id="search",
-        ...             name="web_search",
-        ...             description="Search the web for information"
-        ...         )
-        ...     ]
-        ... )
+        config = A2AServingConfig(
+            port=8080,
+            endpoint="/my-agent",
+            skills=[
+                AgentSkill(
+                    id="search",
+                    name="web_search",
+                    description="Search the web for information"
+                )
+            ]
+        )
 
     """
+
+    model_config = ConfigDict(extra="forbid")
+
+    host: str = "localhost"
+    """Will be passed as argument to `uvicorn.run`."""
+
+    port: int = 5000
+    """Will be passed as argument to `uvicorn.run`."""
+
+    endpoint: str = "/"
+    """Will be pass as argument to `Starlette().add_route`"""
+
+    log_level: str = "warning"
+    """Will be passed as argument to the `uvicorn` server."""
 
     skills: list[AgentSkill] | None = None
     """List of skills to be used by the agent.
@@ -29,4 +40,4 @@ class A2AServingConfig(ServingConfig):
     If not provided, the skills will be inferred from the tools.
     """
 
-    type: Literal["a2a"] = "a2a"
+    version: str = "0.1.0"

--- a/src/any_agent/serving/config.py
+++ b/src/any_agent/serving/config.py
@@ -1,0 +1,22 @@
+from typing import Literal
+
+from a2a.types import AgentSkill
+
+from any_agent.config import ServingConfig
+
+
+class A2AServingConfig(ServingConfig):
+    """Configuration for serving an agent using the Agent2Agent Protocol (A2A)."""
+
+    type: Literal["a2a"] = "a2a"
+    """Type discriminator for A2A serving configuration."""
+
+    skills: list["AgentSkill"] | None = None
+    """List of skills to be used by the agent.
+
+    If not provided, the skills will be inferred from the tools.
+    """
+
+    def get_config_type(self) -> str:
+        """Implementation of abstract method from ServingConfig."""
+        return self.type

--- a/src/any_agent/serving/server.py
+++ b/src/any_agent/serving/server.py
@@ -14,13 +14,13 @@ from .agent_executor import AnyAgentExecutor
 
 if TYPE_CHECKING:
     from any_agent import AnyAgent
-    from any_agent.config import ServingConfig
+    from any_agent.serving import A2AServingConfig
 
 import asyncio
 
 
 def _get_a2a_app(
-    agent: AnyAgent, serving_config: ServingConfig
+    agent: AnyAgent, serving_config: A2AServingConfig
 ) -> A2AStarletteApplication:
     agent_card = _get_agent_card(agent, serving_config)
 

--- a/tests/integration/test_load_and_run_multi_agent_a2a_tool.py
+++ b/tests/integration/test_load_and_run_multi_agent_a2a_tool.py
@@ -6,7 +6,8 @@ from litellm.utils import validate_environment
 from rich.logging import RichHandler
 
 from any_agent import AgentConfig, AgentFramework, AnyAgent
-from any_agent.config import ServingConfig, TracingConfig
+from any_agent.config import TracingConfig
+from any_agent.serving import A2AServingConfig
 from any_agent.tools import a2a_tool
 from any_agent.tracing.agent_trace import AgentTrace
 from tests.conftest import build_tree
@@ -94,7 +95,7 @@ async def test_load_and_run_multi_agent_a2a(
 
         served_agent = date_agent
         (served_task, served_server) = await served_agent.serve_async(
-            serving_config=ServingConfig(
+            serving_config=A2AServingConfig(
                 port=tool_agent_port,
                 endpoint=f"/{tool_agent_endpoint}",
                 log_level="info",

--- a/tests/integration/test_serve_agent.py
+++ b/tests/integration/test_serve_agent.py
@@ -9,7 +9,7 @@ from a2a.types import MessageSendParams, SendMessageRequest
 
 # Import your agent and config
 from any_agent import AgentConfig, AnyAgent
-from any_agent.config import ServingConfig
+from any_agent.serving import A2AServingConfig
 
 SERVER_PORT = 5000
 
@@ -22,7 +22,7 @@ def run_agent():
             description="I'm an agent to help with booking airbnbs",
         ),
     )
-    agent.serve(serving_config=ServingConfig(port=SERVER_PORT))
+    agent.serve(serving_config=A2AServingConfig(port=SERVER_PORT))
 
 
 async def run_agent_async():
@@ -33,7 +33,7 @@ async def run_agent_async():
             description="I'm an agent to help with booking airbnbs",
         ),
     )
-    return await agent.serve_async(serving_config=ServingConfig(port=SERVER_PORT))
+    return await agent.serve_async(serving_config=A2AServingConfig(port=SERVER_PORT))
 
 
 @pytest.mark.asyncio

--- a/tests/unit/serving/test_agent_card.py
+++ b/tests/unit/serving/test_agent_card.py
@@ -3,12 +3,15 @@ from unittest.mock import MagicMock
 import pytest
 
 from any_agent import AgentConfig, AgentFramework
-from any_agent.config import MCPSse, ServingConfig
+from any_agent.config import MCPSse
+from any_agent.serving import A2AServingConfig
 from any_agent.tools import search_web
 from any_agent.tools.mcp import _get_mcp_server
 from any_agent.tools.wrappers import WRAPPERS
 
 try:
+    from a2a.types import AgentSkill
+
     from any_agent.serving.agent_card import _get_agent_card
 except ImportError:
     _get_agent_card = None  # type: ignore[assignment]
@@ -20,7 +23,7 @@ def test_get_agent_card(agent_framework: AgentFramework) -> None:
     agent.config = AgentConfig(model_id="foo", description="test agent")
     agent.framework = agent_framework
     agent._tools = [WRAPPERS[agent_framework](search_web)]
-    agent_card = _get_agent_card(agent, ServingConfig())
+    agent_card = _get_agent_card(agent, A2AServingConfig())
     assert agent_card.name == "any_agent"
     assert agent_card.description == "test agent"
     assert len(agent_card.skills) == 1
@@ -48,10 +51,54 @@ async def test_get_agent_card_with_mcp(  # type: ignore[no-untyped-def]
     else:
         agent._tools = server.tools
 
-    agent_card = _get_agent_card(agent, ServingConfig())
+    agent_card = _get_agent_card(agent, A2AServingConfig())
     assert agent_card.name == "any_agent"
     assert agent_card.description == "test agent"
     assert len(agent_card.skills) == 3
     assert agent_card.skills[0].id == "any_agent-write_file"
     assert agent_card.skills[0].name == "write_file"
     assert agent_card.skills[0].description == "Say hi back with the input text"
+
+
+@pytest.mark.skipif(_get_agent_card is None, reason="a2a_samples is not installed")
+def test_get_agent_card_with_explicit_skills(agent_framework: AgentFramework) -> None:
+    """Test that when skills are explicitly provided in ServingConfig, they are used instead of inferring from tools."""
+    agent = MagicMock()
+    agent.config = AgentConfig(model_id="foo", description="test agent")
+    agent.framework = agent_framework
+    # Give the agent some tools that would normally be used to infer skills
+    agent._tools = [WRAPPERS[agent_framework](search_web)]
+
+    # Create explicit skills that are different from what would be inferred
+    explicit_skills = [
+        AgentSkill(
+            id="custom-skill-1",
+            name="custom_function_1",
+            description="This is a custom skill that does something amazing",
+            tags=["custom", "test"],
+        ),
+        AgentSkill(
+            id="custom-skill-2",
+            name="custom_function_2",
+            description="Another custom skill for testing purposes",
+            tags=["custom", "demo"],
+        ),
+    ]
+
+    serving_config = A2AServingConfig(skills=explicit_skills)
+    agent_card = _get_agent_card(agent, serving_config)
+
+    # Verify basic agent card properties
+    assert agent_card.name == "any_agent"
+    assert agent_card.description == "test agent"
+
+    # Verify that the explicit skills are used (not inferred from tools)
+    assert len(agent_card.skills) == 2
+    assert agent_card.skills[0].id == "custom-skill-1"
+    assert agent_card.skills[1].id == "custom-skill-2"
+
+    # Verify that the skills are NOT the ones that would be inferred from search_web tool
+    skill_names = [skill.name for skill in agent_card.skills]
+    assert (
+        "search_web" not in skill_names
+    )  # This would be present if skills were inferred from tools

--- a/tests/unit/serving/test_agent_card.py
+++ b/tests/unit/serving/test_agent_card.py
@@ -4,7 +4,6 @@ import pytest
 
 from any_agent import AgentConfig, AgentFramework
 from any_agent.config import MCPSse
-from any_agent.serving import A2AServingConfig
 from any_agent.tools import search_web
 from any_agent.tools.mcp import _get_mcp_server
 from any_agent.tools.wrappers import WRAPPERS
@@ -12,6 +11,7 @@ from any_agent.tools.wrappers import WRAPPERS
 try:
     from a2a.types import AgentSkill
 
+    from any_agent.serving import A2AServingConfig
     from any_agent.serving.agent_card import _get_agent_card
 except ImportError:
     _get_agent_card = None  # type: ignore[assignment]
@@ -62,7 +62,7 @@ async def test_get_agent_card_with_mcp(  # type: ignore[no-untyped-def]
 
 @pytest.mark.skipif(_get_agent_card is None, reason="a2a_samples is not installed")
 def test_get_agent_card_with_explicit_skills(agent_framework: AgentFramework) -> None:
-    """Test that when skills are explicitly provided in ServingConfig, they are used instead of inferring from tools."""
+    """Test that when skills are explicitly provided in A2AServingConfig, they are used instead of inferring from tools."""
     agent = MagicMock()
     agent.config = AgentConfig(model_id="foo", description="test agent")
     agent.framework = agent_framework

--- a/tests/unit/tools/test_a2a.py
+++ b/tests/unit/tools/test_a2a.py
@@ -1,11 +1,17 @@
 import asyncio
 from unittest.mock import patch
 
-from a2a.types import AgentCapabilities, AgentCard
+import pytest
 
-from any_agent.tools.a2a import a2a_tool
+try:
+    from a2a.types import AgentCapabilities, AgentCard
+
+    from any_agent.tools.a2a import a2a_tool
+except ImportError:
+    a2a_tool = None
 
 
+@pytest.mark.skipif(a2a_tool is None, reason="a2a is not installed")
 def test_a2a_tool_name_default():
     fun_name = "some_name"
     with patch("any_agent.tools.a2a.A2ACardResolver.get_agent_card") as agent_card_mock:
@@ -23,6 +29,7 @@ def test_a2a_tool_name_default():
         assert created_fun.__name__ == f"call_{fun_name}"
 
 
+@pytest.mark.skipif(a2a_tool is None, reason="a2a is not installed")
 def test_a2a_tool_name_specific():
     other_name = "other_name"
     with patch("any_agent.tools.a2a.A2ACardResolver.get_agent_card") as agent_card_mock:
@@ -40,6 +47,7 @@ def test_a2a_tool_name_specific():
         assert created_fun.__name__ == f"call_{other_name}"
 
 
+@pytest.mark.skipif(a2a_tool is None, reason="a2a is not installed")
 def test_a2a_tool_name_whitespace():
     fun_name = "  some_n  ame  "
     corrected_fun_name = "some_n_ame"
@@ -58,6 +66,7 @@ def test_a2a_tool_name_whitespace():
         assert created_fun.__name__ == f"call_{corrected_fun_name}"
 
 
+@pytest.mark.skipif(a2a_tool is None, reason="a2a is not installed")
 def test_a2a_tool_name_exotic_whitespace():
     fun_name = " \n so \t me_n\t ame  \n"
     corrected_fun_name = "so_me_n_ame"
@@ -76,6 +85,7 @@ def test_a2a_tool_name_exotic_whitespace():
         assert created_fun.__name__ == f"call_{corrected_fun_name}"
 
 
+@pytest.mark.skipif(a2a_tool is None, reason="a2a is not installed")
 def test_a2a_tool_name_specific_whitespace():
     other_name = " \n oth \t er_n\t ame  \n"
     corrected_other_name = "oth_er_n_ame"


### PR DESCRIPTION
Now the skills are configurable and I also tweak the API so that it clears the path to allow for future integration of other serving methods like Serving over MCP or ACP.

A2AServingConfig now has an a2a specific type called "AgentSkill" which is no longer appropriate to exist in the main ServingConfig class. This is why I made a new config and put it inside of the `serving` module.

Other than the re-org, the actual code change is in the _get_agent_card function. I also created a unit test.