### PR TITLE
Return spans in exception if the invocation fails

### DIFF
--- a/src/any_agent/__init__.py
+++ b/src/any_agent/__init__.py
@@ -1,10 +1,11 @@
 from .config import AgentConfig, AgentFramework, TracingConfig
-from .frameworks.any_agent import AnyAgent
+from .frameworks.any_agent import AgentRunException, AnyAgent
 from .tracing.agent_trace import AgentTrace
 
 __all__ = [
     "AgentConfig",
     "AgentFramework",
+    "AgentRunException",
     "AgentTrace",
     "AnyAgent",
     "TracingConfig",

--- a/src/any_agent/frameworks/any_agent.py
+++ b/src/any_agent/frameworks/any_agent.py
@@ -14,6 +14,7 @@ from any_agent.config import (
     TracingConfig,
 )
 from any_agent.tools.wrappers import _wrap_tools
+from any_agent.tracing.agent_trace import AgentSpan
 from any_agent.tracing.exporter import _AnyAgentExporter
 from any_agent.tracing.instrumentation import (
     _get_instrumentor_by_framework,
@@ -29,6 +30,17 @@ if TYPE_CHECKING:
     from any_agent.serving.config import A2AServingConfig
     from any_agent.tools.mcp.mcp_server import _MCPServerBase
     from any_agent.tracing.agent_trace import AgentTrace
+
+
+class AgentRunException(Exception):
+    _spans: list[AgentSpan]
+
+    def __init__(self, spans: list[AgentSpan]):
+        self._spans = spans
+
+    @property
+    def spans(self):
+        return self._spans
 
 
 class AnyAgent(ABC):
@@ -153,23 +165,27 @@ class AnyAgent(ABC):
     async def run_async(self, prompt: str, **kwargs: Any) -> AgentTrace:
         """Run the agent asynchronously with the given prompt."""
         run_id = str(uuid4())
-        with self._tracer.start_as_current_span(
-            f"invoke_agent [{self.config.name}]"
-        ) as invoke_span:
-            invoke_span.set_attributes(
-                {
-                    "gen_ai.operation.name": "invoke_agent",
-                    "gen_ai.agent.name": self.config.name,
-                    "gen_ai.agent.description": self.config.description
-                    or "No description.",
-                    "gen_ai.request.model": self.config.model_id,
-                    "gen_ai.request.id": run_id,
-                }
-            )
-            final_output = await self._run_async(prompt, **kwargs)
-        trace = self._exporter.pop_trace(run_id)  # type: ignore[union-attr]
-        trace.final_output = final_output
-        return trace
+        try:
+            with self._tracer.start_as_current_span(
+                f"invoke_agent [{self.config.name}]"
+            ) as invoke_span:
+                invoke_span.set_attributes(
+                    {
+                        "gen_ai.operation.name": "invoke_agent",
+                        "gen_ai.agent.name": self.config.name,
+                        "gen_ai.agent.description": self.config.description
+                        or "No description.",
+                        "gen_ai.request.model": self.config.model_id,
+                        "gen_ai.request.id": run_id,
+                    }
+                )
+                final_output = await self._run_async(prompt, **kwargs)
+            trace = self._exporter.pop_trace(run_id)  # type: ignore[union-attr]
+            trace.final_output = final_output
+            return trace
+        except Exception as e:
+            trace = self._exporter.pop_trace(run_id)  # type: ignore[union-attr]
+            raise AgentRunException(trace.spans) from e
 
     def serve(self, serving_config: A2AServingConfig | None = None) -> None:
         """Serve this agent using the protocol defined in the serving_config.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from litellm.types.utils import ModelResponse
+from litellm.types.utils import ModelResponse as LLMModelResponse
 
 from any_agent.config import AgentFramework
 from any_agent.logging import setup_logger
@@ -15,6 +15,15 @@ from any_agent.tracing.agent_trace import AgentSpan, AgentTrace
 
 BASE_PORT = 5800
 PORT_PER_FRAMEWORK = {fw: BASE_PORT + index for index, fw in enumerate(AgentFramework)}
+PATCH_PER_FRAMEWORK = {
+    AgentFramework.AGNO: "agno.tools.function.FunctionCall.execute",
+    AgentFramework.GOOGLE: "google.adk.tools.function_tool.FunctionTool.run_async",
+    AgentFramework.LANGCHAIN: "langchain_core.tools.structured.StructuredTool._run",
+    AgentFramework.LLAMA_INDEX: "llama_index.core.tools.function_tool.sync_to_async",
+    AgentFramework.OPENAI: "langchain_core.tools.structured.StructuredTool._run",
+    AgentFramework.SMOLAGENTS: "smolagents.agents.ToolCallingAgent.execute_tool_call",
+    AgentFramework.TINYAGENT: "any_agent.frameworks.tinyagent.ToolExecutor.call_tool",
+}
 
 
 @pytest.fixture(params=list(AgentFramework), ids=lambda x: x.name)
@@ -25,6 +34,11 @@ def agent_framework(request: pytest.FixtureRequest) -> AgentFramework:
 @pytest.fixture
 def tool_agent_port(agent_framework):
     return PORT_PER_FRAMEWORK[agent_framework]
+
+
+@pytest.fixture
+def patched_function(agent_framework):
+    return PATCH_PER_FRAMEWORK[agent_framework]
 
 
 @pytest.fixture
@@ -100,9 +114,9 @@ def configure_logging(pytestconfig: pytest.Config) -> None:
 
 
 @pytest.fixture
-def mock_litellm_response() -> ModelResponse:
+def mock_litellm_response() -> LLMModelResponse:
     """Fixture to create a standard mock LiteLLM response"""
-    return ModelResponse.model_validate_json(
+    return LLMModelResponse.model_validate_json(
         '{"id":"chatcmpl-BWnfbHWPsQp05roQ06LAD1mZ9tOjT","created":1747157127,"model":"gpt-4o-2024-08-06","object":"chat.completion","system_fingerprint":"fp_f5bdcc3276","choices":[{"finish_reason":"stop","index":0,"message":{"content":"The state capital of Pennsylvania is Harrisburg.","role":"assistant","tool_calls":null,"function_call":null,"annotations":[]}}],"usage":{"completion_tokens":11,"prompt_tokens":138,"total_tokens":149,"completion_tokens_details":{"accepted_prediction_tokens":0,"audio_tokens":0,"reasoning_tokens":0,"rejected_prediction_tokens":0},"prompt_tokens_details":{"audio_tokens":0,"cached_tokens":0}},"service_tier":"default"}'
     )
 

--- a/tests/integration/test_load_and_run_agent.py
+++ b/tests/integration/test_load_and_run_agent.py
@@ -5,11 +5,18 @@ import time
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 from litellm.utils import validate_environment
 
-from any_agent import AgentConfig, AgentFramework, AnyAgent, TracingConfig
+from any_agent import (
+    AgentConfig,
+    AgentFramework,
+    AgentRunException,
+    AnyAgent,
+    TracingConfig,
+)
 from any_agent.config import MCPStdio
 from any_agent.evaluation import EvaluationCase, evaluate
 from any_agent.evaluation.schemas import (
@@ -18,6 +25,7 @@ from any_agent.evaluation.schemas import (
     TraceEvaluationResult,
 )
 from any_agent.tracing.agent_trace import AgentSpan, AgentTrace, CostInfo, TokenInfo
+from any_agent.tracing.otel_types import StatusCode
 
 
 def uvx_installed() -> bool:
@@ -221,5 +229,96 @@ def test_load_and_run_agent(
 
         agent.exit()
         assert_eval(agent_trace)
+    finally:
+        agent.exit()
+
+
+@pytest.mark.skipif(
+    os.environ.get("ANY_AGENT_INTEGRATION_TESTS", "FALSE").upper() != "TRUE",
+    reason="Integration tests require `ANY_AGENT_INTEGRATION_TESTS=TRUE` env var",
+)
+def test_exception_trace(
+    agent_framework: AgentFramework,
+    patched_function: str,
+    tmp_path: Path,
+    request: pytest.FixtureRequest,
+) -> None:
+    if agent_framework in (
+        # LangChain does not trigger the tool
+        AgentFramework.LANGCHAIN,
+        # Llama Index wraps the function, so patching it becomes more difficult
+        AgentFramework.LLAMA_INDEX,
+        # OPENAI wraps the function, so patching it becomes more difficult
+        AgentFramework.OPENAI,
+    ):
+        pytest.skip(f"Framework {agent_framework.value} not currently passing the test")
+
+    kwargs = {}
+
+    tmp_file = "tmp.txt"
+    # FIXME patch some call so an exception is triggered
+    # An exception within a tool will be handled by the framework
+    exc_reason = "the tool broke!"
+
+    if not uvx_installed():
+        msg = "uvx is not installed. Please install it to run this test."
+        raise RuntimeError(msg)
+
+    def fail_tool(text: str) -> None:
+        """write the text to a file in the tmp_path directory
+
+        Args:
+            text (str): The text to write to the file.
+
+        Returns:
+            None
+        """
+        with open(os.path.join(tmp_path, tmp_file), "w", encoding="utf-8") as f:
+            f.write(text)
+
+    kwargs["model_id"] = "gpt-4.1-mini"
+    env_check = validate_environment(kwargs["model_id"])
+    if not env_check["keys_in_environment"]:
+        pytest.skip(f"{env_check['missing_keys']} needed for {agent_framework}")
+
+    model_args: dict[str, Any] = (
+        {"parallel_tool_calls": False}
+        if agent_framework not in [AgentFramework.AGNO, AgentFramework.LLAMA_INDEX]
+        else {}
+    )
+    model_args["temperature"] = 0.5
+    tools = [
+        fail_tool,
+    ]
+    agent_config = AgentConfig(
+        tools=tools,  # type: ignore[arg-type]
+        instructions="Answer the query.",
+        model_args=model_args,
+        **kwargs,  # type: ignore[arg-type]
+    )
+    agent = AnyAgent.create(agent_framework, agent_config, tracing=TracingConfig())
+    update_trace = request.config.getoption("--update-trace-assets")
+    if update_trace:
+        agent._exporter.console.record = True  # type: ignore[union-attr]
+
+    try:
+        with patch(patched_function) as fw_agent_runtool:
+            fw_agent_runtool.side_effect = RuntimeError(exc_reason)
+            spans = []
+            start_ns = time.time_ns()
+            try:
+                agent.run(
+                    "Write a four-line poem and use the tools to write it to a file.",
+                )
+            except AgentRunException as are:
+                spans = are.spans
+            end_ns = time.time_ns()
+            assert any(
+                [
+                    span.status.status_code == StatusCode.ERROR
+                    and exc_reason in span.status.description
+                    for span in spans
+                ]
+            )
     finally:
         agent.exit()


### PR DESCRIPTION
If the invocation fails due to some error that is not caught by the underlying platform, an `AgentRunException` will be thrown, having as `__cause__` the original exception, and keeping the created spans so far in the `spans` property. Note that many platforms will catch a large amount of errors in tools and wrap them in their own spans, with varying status codes.