### PR TITLE
Dynamic port assignment in async tests

### DIFF
--- a/src/any_agent/serving/server.py
+++ b/src/any_agent/serving/server.py
@@ -61,6 +61,9 @@ async def serve_a2a_async(
     task = asyncio.create_task(uv_server.serve())
     while not uv_server.started:  # noqa: ASYNC110
         await asyncio.sleep(0.1)
+    if port == 0:
+        server_port = uv_server.servers[0].sockets[0].getsockname()[1]
+        server.agent_card.url = f"http://{host}:{server_port}/{endpoint.lstrip("/")}"
     return (task, uv_server)
 
 

--- a/tests/integration/test_load_and_run_multi_agent_a2a_tool.py
+++ b/tests/integration/test_load_and_run_multi_agent_a2a_tool.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 import os
 from multiprocessing import Process
+import asyncio
 
 import pytest
 from litellm.utils import validate_environment
@@ -67,7 +68,7 @@ DATE_PROMPT = (
 )
 @pytest.mark.asyncio
 async def test_load_and_run_multi_agent_a2a(
-    agent_framework: AgentFramework, test_port: int
+    agent_framework: AgentFramework
 ) -> None:
     """Tests that an agent contacts another using A2A using the adapter tool.
 
@@ -133,12 +134,14 @@ async def test_load_and_run_multi_agent_a2a(
         served_agent = date_agent
         (served_task, served_server) = await served_agent.serve_async(
             serving_config=A2AServingConfig(
-                port=test_port,
+                port=0,
                 endpoint=f"/{tool_agent_endpoint}",
                 log_level="info",
             )
         )
+        test_port = served_server.servers[0].sockets[0].getsockname()[1]
         server_url = f"http://localhost:{test_port}/{tool_agent_endpoint}"
+        print(f"--> Serving at {server_url}")
         await wait_for_server_async(server_url)
 
         # Search agent is ready for card resolution


### PR DESCRIPTION
The port can be left to 0, so the OS will assign any to the server. However, the agentcard needs to be updated since its url will have port=0.