### PR TITLE
fix(llama_index): Don't set `allowed_tools` to empty list.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ langchain = [
 llama_index = [
   "llama-index",
   "llama-index-llms-litellm",
-  "llama-index-tools-mcp==0.2.1",
+  "llama-index-tools-mcp>=0.2.5",
   "platformdirs>=4.3.7",
 ]
 

--- a/src/any_agent/tools/mcp/frameworks/llama_index.py
+++ b/src/any_agent/tools/mcp/frameworks/llama_index.py
@@ -32,9 +32,12 @@ class LlamaIndexMCPConnection(_MCPConnection["LlamaIndexFunctionTool"], ABC):
             msg = "MCP client is not set up. Please call `list_tool` from a concrete class."
             raise ValueError(msg)
 
+        allowed_tools = self.mcp_tool.tools
+        if allowed_tools is not None:
+            allowed_tools = list(allowed_tools)
         mcp_tool_spec = LlamaIndexMcpToolSpec(
             client=self._client,
-            allowed_tools=list(self.mcp_tool.tools or []),
+            allowed_tools=allowed_tools,
         )
 
         return await mcp_tool_spec.to_tool_list_async()


### PR DESCRIPTION
Similar issue we had with Agno a while back. The internal code expects `None` instead of empty list:

https://github.com/run-llama/llama_index/blob/98739a603768e37a98c70275113d98e5d1f0979e/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/base.py#L95-L97