### PR TITLE
chore: unpin frozenlist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,7 +172,6 @@ tests = [
   "debugpy>=1.8.13",
   "mktestdocs>=0.2.4",
   "syrupy>=4.9.1",
-  "frozenlist==1.6.0", # Until this is fixed https://github.com/aio-libs/frozenlist/issues/658
 ]
 
 # For completeness, but 'uv sync --group dev' currently installs the others too.


### PR DESCRIPTION
https://github.com/aio-libs/frozenlist/issues/658 has been fixed so we can unpin