### PR TITLE
chore(tests): Remove reliance on `ANY_AGENT_INTEGRATION_TESTS` env

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,6 +40,5 @@ jobs:
       - name: Run Integration tests (parallel with xdist)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
         env:
-          ANY_AGENT_INTEGRATION_TESTS: TRUE
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: pytest -v tests/integration -d --tx '4*popen//python=python'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,6 @@ We welcome all kinds of contributions, from improving customization, to extendin
 - Install the package using development dependencies before testing: `uv sync --group dev --extra all`
 - Integration tests need the following environment variables to be set:
   ```
-  ANY_AGENT_INTEGRATION_TESTS=TRUE
   OPENAI_API_KEY="YOUR API KEY"
   ```
 

--- a/tests/integration/test_load_and_run_agent.py
+++ b/tests/integration/test_load_and_run_agent.py
@@ -141,10 +141,6 @@ def assert_eval(agent_trace: AgentTrace) -> None:
     assert result.score >= float(1 / 3)
 
 
-@pytest.mark.skipif(
-    os.environ.get("ANY_AGENT_INTEGRATION_TESTS", "FALSE").upper() != "TRUE",
-    reason="Integration tests require `ANY_AGENT_INTEGRATION_TESTS=TRUE` env var",
-)
 def test_load_and_run_agent(
     agent_framework: AgentFramework, tmp_path: Path, request: pytest.FixtureRequest
 ) -> None:
@@ -231,10 +227,6 @@ def test_load_and_run_agent(
     assert_eval(agent_trace)
 
 
-@pytest.mark.skipif(
-    os.environ.get("ANY_AGENT_INTEGRATION_TESTS", "FALSE").upper() != "TRUE",
-    reason="Integration tests require `ANY_AGENT_INTEGRATION_TESTS=TRUE` env var",
-)
 def test_exception_trace(
     agent_framework: AgentFramework,
     patched_function: str,

--- a/tests/integration/test_load_and_run_multi_agent_a2a_tool.py
+++ b/tests/integration/test_load_and_run_multi_agent_a2a_tool.py
@@ -1,6 +1,5 @@
 import datetime
 import logging
-import os
 from multiprocessing import Process, Queue
 
 import pytest
@@ -60,10 +59,6 @@ DATE_PROMPT = (
 )
 
 
-@pytest.mark.skipif(
-    os.environ.get("ANY_AGENT_INTEGRATION_TESTS", "FALSE").upper() != "TRUE",
-    reason="Integration tests require `ANY_AGENT_INTEGRATION_TESTS=TRUE` env var",
-)
 @pytest.mark.asyncio
 async def test_load_and_run_multi_agent_a2a(agent_framework: AgentFramework) -> None:
     """Tests that an agent contacts another using A2A using the adapter tool.
@@ -231,10 +226,6 @@ def _run_server(
     )
 
 
-@pytest.mark.skipif(
-    os.environ.get("ANY_AGENT_INTEGRATION_TESTS", "FALSE").upper() != "TRUE",
-    reason="Integration tests require `ANY_AGENT_INTEGRATION_TESTS=TRUE` env var",
-)
 def test_load_and_run_multi_agent_a2a_sync(agent_framework: AgentFramework) -> None:
     """Tests that an agent contacts another using A2A using the sync adapter tool.
 

--- a/tests/integration/test_no_instrument.py
+++ b/tests/integration/test_no_instrument.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 from litellm.utils import validate_environment
 
@@ -7,10 +5,6 @@ from any_agent import AgentConfig, AgentFramework, AnyAgent
 from any_agent.tools import search_tavily
 
 
-@pytest.mark.skipif(
-    os.environ.get("ANY_AGENT_INTEGRATION_TESTS", "FALSE").upper() != "TRUE",
-    reason="Integration tests require `ANY_AGENT_INTEGRATION_TESTS=TRUE` env var",
-)
 def test_no_instrument(
     agent_framework: AgentFramework,
 ) -> None:


### PR DESCRIPTION
Since we run tests via `pytest tests/integration` there's no reason to keep this env var imo. We run either unit or integration tests by specifying the specific pytest folder we want.