### PR TITLE
feat(agent): Add resume_from functionality to agent run methods

### DIFF
--- a/src/any_agent/frameworks/any_agent.py
+++ b/src/any_agent/frameworks/any_agent.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-from abc import ABC, abstractmethod
 import json
+from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, assert_never
 
 from opentelemetry import trace
@@ -141,12 +141,20 @@ class AnyAgent(ABC):
             tools.extend(mcp_server.tools)
         return tools, mcp_servers
 
-    def run(self, prompt: str, resume_from: AgentTrace | None = None, **kwargs: Any) -> AgentTrace:
+    def run(
+        self, prompt: str, resume_from: AgentTrace | None = None, **kwargs: Any
+    ) -> AgentTrace:
         """Run the agent with the given prompt."""
-        return run_async_in_sync(self.run_async(prompt=prompt, resume_from=resume_from, **kwargs))
+        return run_async_in_sync(
+            self.run_async(prompt=prompt, resume_from=resume_from, **kwargs)
+        )
 
     async def run_async(
-        self, prompt: str, instrument: bool = True, resume_from: AgentTrace | None = None, **kwargs: Any
+        self,
+        prompt: str,
+        instrument: bool = True,
+        resume_from: AgentTrace | None = None,
+        **kwargs: Any,
     ) -> AgentTrace:
         """Run the agent asynchronously with the given prompt.
 
@@ -169,9 +177,14 @@ class AnyAgent(ABC):
         """
         if resume_from is not None:
             # Construct a "history" string that can be prepended to the prompt
-            history = "\n".join([json.dumps(span.attributes) for span in resume_from.spans if span.attributes is not None])
+            history = "\n".join(
+                [
+                    json.dumps(span.attributes)
+                    for span in resume_from.spans
+                    if span.attributes is not None
+                ]
+            )
             prompt = f"History:\n{history}\nPrompt:\n{prompt}"
-            print(f"Resuming from history: {history}")
 
         try:
             trace = AgentTrace()

--- a/tests/integration/test_load_and_run_agent.py
+++ b/tests/integration/test_load_and_run_agent.py
@@ -5,11 +5,11 @@ import time
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
-from pydantic import BaseModel
 from unittest.mock import patch
 
 import pytest
 from litellm.utils import validate_environment
+from pydantic import BaseModel
 
 from any_agent import (
     AgentConfig,
@@ -314,7 +314,9 @@ def test_exception_trace(
 def test_resume_from_feature(agent_framework: AgentFramework, tmp_path: Path) -> None:
     """Test that the agent can resume from a previous trace using the resume_from argument."""
     if agent_framework is AgentFramework.GOOGLE:
-        pytest.skip("Google infinite recursion bug: https://github.com/mozilla-ai/any-agent/issues/467 prevents this test from passing")
+        pytest.skip(
+            "Google infinite recursion bug: https://github.com/mozilla-ai/any-agent/issues/467 prevents this test from passing"
+        )
     kwargs = {}
     kwargs["model_id"] = "gpt-4.1-mini"
     env_check = validate_environment(kwargs["model_id"])
@@ -335,7 +337,5 @@ def test_resume_from_feature(agent_framework: AgentFramework, tmp_path: Path) ->
     )
     assert trace1.final_output.year == 2000
 
-    trace2 = agent.run(
-        "Now increment the year by 5.", resume_from=trace1
-    )
+    trace2 = agent.run("Now increment the year by 5.", resume_from=trace1)
     assert trace2.final_output.year == 2005


### PR DESCRIPTION
I'd like to open this up for discussion before I get too deep.

I see two paths:

1. Leverage each existing frameworks "resume" functionality, if it exists. Pros: maybe there is some caching they do to lower latency or cost of making a big initial LLM call? I would need to dig into each framework to see if that is happening.

2. Write our own wrapper that takes the last AgentTrace, extracts the previous messages, and prepends it to their prompt (This is the approach I went with in this PR)


Generally I like path 2, because this makes it pretty simple to handle across all the frameworks, but it certainly breaks any message caching that frameworks might have used in LiteLLM https://docs.litellm.ai/docs/proxy/caching

So, maybe for right now we could implement this as a sort of "brute force" approach but we could refine it as we go, and probably could do internally so that it wouldn't require any future changes to the API after this initial addition of the `resume_from` parameter.

I'm also adding @HareeshBahuleyan  and @stefanfrench  here as the conclusions we reach here may help the agent-factory design (if we do this PR right 😅 )