### PR TITLE
Address pydantic deprecation warning

### DIFF
--- a/src/any_agent/serving/envelope.py
+++ b/src/any_agent/serving/envelope.py
@@ -34,7 +34,7 @@ class A2AEnvelope(BaseModel, Generic[BodyType]):
 def _is_a2a_envelope(typ: type[BaseModel] | None) -> bool:
     if typ is None:
         return False
-    fields: Any = getattr(typ, "__fields__", None)
+    fields: Any = getattr(typ, "model_fields", None)
 
     # We only care about a mapping with the required keys.
     if not isinstance(fields, Mapping):


### PR DESCRIPTION
  /Users/nbrake/scm/any-agent/src/any_agent/serving/envelope.py:37: PydanticDeprecatedSince20: The `__fields__` attribute is deprecated, use `model_fields` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/
    fields: Any = getattr(typ, "__fields__", None)