### PR TITLE
feat(agent): Enhance final output handling with retry logic and JSON validation

### DIFF
--- a/src/any_agent/frameworks/google.py
+++ b/src/any_agent/frameworks/google.py
@@ -99,6 +99,9 @@ class GoogleAgent(AnyAgent):
 
         if self.config.output_type:
             final_output = None
+            final_output_attempts = 0
+            max_attempts = 3
+
             async for event in runner.run_async(
                 user_id=user_id,
                 session_id=session_id,
@@ -107,28 +110,30 @@ class GoogleAgent(AnyAgent):
             ):
                 if not event.content or not event.content.parts:
                     continue
-                if any(
-                    part.function_response
-                    and part.function_response.name == "final_output"
-                    and part.function_response.response
-                    and part.function_response.response.get("success")
-                    for part in event.content.parts
-                ):
-                    # Extract the final output from the successful function response
-                    for part in event.content.parts:
-                        if (
-                            part.function_response
-                            and part.function_response.name == "final_output"
-                            and part.function_response.response
-                            and part.function_response.response.get("success")
-                        ):
+
+                # Check for final_output function responses
+                for part in event.content.parts:
+                    if (
+                        part.function_response
+                        and part.function_response.name == "final_output"
+                        and part.function_response.response
+                    ):
+                        final_output_attempts += 1
+                        if part.function_response.response.get("success"):
                             final_output = part.function_response.response.get("result")
                             break
+                        if final_output_attempts >= max_attempts:
+                            msg = f"Final output failed after {final_output_attempts} attempts"
+                            raise ValueError(msg)
+
+                if final_output or final_output_attempts >= max_attempts:
                     break
+
             if not final_output:
                 msg = "No final response found"
                 raise ValueError(msg)
             return self.config.output_type.model_validate_json(final_output)
+
         async for _ in runner.run_async(
             user_id=user_id,
             session_id=session_id,

--- a/src/any_agent/frameworks/google.py
+++ b/src/any_agent/frameworks/google.py
@@ -100,7 +100,8 @@ class GoogleAgent(AnyAgent):
         if self.config.output_type:
             final_output = None
             final_output_attempts = 0
-            max_attempts = 3
+            # We allow for two retries: one to make it a proper json string, and one to make it a valid pydantic model
+            max_output_attepts = 3
 
             async for event in runner.run_async(
                 user_id=user_id,
@@ -122,11 +123,11 @@ class GoogleAgent(AnyAgent):
                         if part.function_response.response.get("success"):
                             final_output = part.function_response.response.get("result")
                             break
-                        if final_output_attempts >= max_attempts:
+                        if final_output_attempts >= max_output_attepts:
                             msg = f"Final output failed after {final_output_attempts} attempts"
                             raise ValueError(msg)
 
-                if final_output or final_output_attempts >= max_attempts:
+                if final_output or final_output_attempts >= max_output_attepts:
                     break
 
             if not final_output:

--- a/src/any_agent/tools/final_output.py
+++ b/src/any_agent/tools/final_output.py
@@ -27,16 +27,16 @@ class FinalOutputTool:
 
     def __call__(self, answer: str) -> dict:  # type: ignore[type-arg]
         """Validate the final output."""
+        # First check if it's valid JSON
         try:
-            # First check if it's valid JSON
-            try:
-                json.loads(answer)
-            except json.JSONDecodeError as json_err:
-                return {
-                    "success": False,
-                    "result": f"Invalid JSON format: {json_err}. Please provide valid JSON.",
-                }
-            # Then validate against the Pydantic model
+            json.loads(answer)
+        except json.JSONDecodeError as json_err:
+            return {
+                "success": False,
+                "result": f"Invalid JSON format: {json_err}. Please provide valid JSON.",
+            }
+        # Then validate against the Pydantic model
+        try:
             self.output_type.model_validate_json(answer)
         except ValidationError as e:
             return {

--- a/src/any_agent/tools/final_output.py
+++ b/src/any_agent/tools/final_output.py
@@ -1,3 +1,5 @@
+import json
+
 from pydantic import BaseModel, ValidationError
 
 
@@ -26,6 +28,15 @@ class FinalOutputTool:
     def __call__(self, answer: str) -> dict:  # type: ignore[type-arg]
         """Validate the final output."""
         try:
+            # First check if it's valid JSON
+            try:
+                json.loads(answer)
+            except json.JSONDecodeError as json_err:
+                return {
+                    "success": False,
+                    "result": f"Invalid JSON format: {json_err}. Please provide valid JSON.",
+                }
+            # Then validate against the Pydantic model
             self.output_type.model_validate_json(answer)
         except ValidationError as e:
             return {

--- a/tests/unit/tools/mcp/test_unit_openai_mcp.py
+++ b/tests/unit/tools/mcp/test_unit_openai_mcp.py
@@ -64,7 +64,6 @@ async def test_openai_mcp_env() -> None:
         assert mocked_class.call_args_list[0][1]["params"]["env"] == {"FOO": "BAR"}
 
 
-@pytest.mark.asyncio
 def test_openai_client_session_timeout_passed():
     """Test that client_session_timeout_seconds parameter is properly passed to OpenAI MCPServerStdio and MCPServerSse."""
     custom_timeout = 15.0


### PR DESCRIPTION
Two things here: one fix, and one "infinite loop til max steps" fix.

The problem: Google wasn't getting the hint that the problem wasn't with the info provided, but the fact that it was providing a direct string and not a json string. 
![Screenshot 2025-06-16 at 11 23 02 AM](https://github.com/user-attachments/assets/5e122469-19a9-4c55-9ac8-61d2ec3e6149)

The fix: Use a two stage validation approach. Step one, make sure they passed a valid json string, if not, return an error saying that it's invalid JSON. Step two, once it's valid JSON, then we can try to parse it with pydantic.
Now:

![Screenshot 2025-06-16 at 11 24 38 AM](https://github.com/user-attachments/assets/5b77d63e-c1eb-43e8-b76c-5c7a7c921d73)


