### PR TITLE
Make any_agent.__version__ attribute available

### DIFF
--- a/src/any_agent/__init__.py
+++ b/src/any_agent/__init__.py
@@ -7,7 +7,9 @@ from .tracing.agent_trace import AgentTrace
 try:
     __version__ = version("any-agent")
 except PackageNotFoundError:
-    __version__ = "unknown"
+    # In the case of local development
+    # i.e., running directly from the source directory without package being installed
+    __version__ = "0.0.0-dev"
 
 __all__ = [
     "AgentConfig",


### PR DESCRIPTION
Currently it fails when I run `print(any_agent.__version__)`

I tested if it works from this branch by doing the following:

```
# Create a temp env
mamba create -n test-env python=3.11
mamba activate test-env

# Install from this branch
pip install "git+https://github.com/mozilla-ai/any-agent.git@package-version#egg=any-agent[all]"

# Test version displayed correctly
python -c "import any_agent; print(any_agent.__version__)"
```