### PR TITLE
fix(agent): Agent is allowed to have multiturn conversation with another agent

### DIFF
--- a/src/any_agent/serving/agent_executor.py
+++ b/src/any_agent/serving/agent_executor.py
@@ -55,8 +55,7 @@ class AnyAgentExecutor(AgentExecutor):  # type: ignore[misc]
         agent_trace = await self.agent.run_async(formatted_query)
 
         # Update task with new trace
-        if task:
-            self.task_manager.update_task_trace(task.id, agent_trace)
+        self.task_manager.update_task_trace(task.id, agent_trace)
 
         updater = TaskUpdater(event_queue, task.id, task.contextId)
 

--- a/src/any_agent/tools/a2a.py
+++ b/src/any_agent/tools/a2a.py
@@ -51,7 +51,7 @@ async def a2a_tool_async(
             A2ACardResolver(httpx_client=resolver_client, base_url=url)
         ).get_agent_card()
 
-    async def _send_query(query: str) -> str:
+    async def _send_query(query: str, task_id: str = str(uuid4())) -> str:
         async with httpx.AsyncClient(follow_redirects=True) as query_client:
             client = A2AClient(httpx_client=query_client, agent_card=a2a_agent_card)
             send_message_payload = SendMessageRequest(
@@ -61,7 +61,8 @@ async def a2a_tool_async(
                         role=Role.user,
                         parts=[Part(root=TextPart(text=query))],
                         # the id is not currently tracked
-                        messageId=uuid4().hex,
+                        messageId=str(uuid4().hex),
+                        taskId=task_id,
                     )
                 ),
             )
@@ -104,6 +105,7 @@ async def a2a_tool_async(
 
         Args:
             query (str): The query to perform.
+            task_id (str): The task id to use for the conversation. Defaults to a new uuid. If you want to continue the conversation, you should provide the same task id that you received in a previous response.
 
         Returns:
             The result from the A2A agent, encoded as a json string.


### PR DESCRIPTION
This approach works (as evidenced by the integration test) and I think is sufficient for a first implementation. However, I'm not totally convinced that the implementation is incredibly stable. Asking an LLM to properly pass a UUID around seems risky. Although, it only has to copy and past the UUID, it's not like it needs to calculate the UUID. This could be a tool that could be further stabilized if we had some sort of "memory as a tool" feature. Something to think about for the future.