### PR TITLE
Improve reliability of test, decrease token use of

### DIFF
--- a/src/any_agent/tools/a2a.py
+++ b/src/any_agent/tools/a2a.py
@@ -84,7 +84,10 @@ async def a2a_tool_async(
                 )
             elif hasattr(response.root, "result"):
                 result = response.root.result.model_dump_json(
-                    exclude_none=True, exclude_unset=True, exclude_defaults=True
+                    exclude={"history"},
+                    exclude_none=True,
+                    exclude_unset=True,
+                    exclude_defaults=True,
                 )
             else:
                 msg = (

--- a/tests/integration/test_multiturn.py
+++ b/tests/integration/test_multiturn.py
@@ -64,7 +64,7 @@ class MockConversationAgent(TinyAgent):
     async def run_async(self, prompt: str, **kwargs) -> AgentTrace:
         if self.turn_count == 0:
             # First turn: User introduces themselves
-            assert FIRST_TURN_PROMPT == prompt
+            assert FIRST_TURN_PROMPT in prompt
             self.turn_count += 1
             envelope = self.output_type(
                 task_status=TaskState.completed,


### PR DESCRIPTION
* make the assert an 'in' instead of '==' because nano was appending `1. ` to the beginning of the prompt which is ok because I guess technically I did have those numbers in the prompt, although mini wasn't including them and nano wasn't including them yesterday 🤷 


I also excluded the `history` key from what the a2a_tool returns to reduce token usage and to focus on only providing back to the client agent the content of the result.