### PR TITLE
fix: enhance AgentRunError to be readable and include original exception details 

### DIFF
--- a/src/any_agent/frameworks/any_agent.py
+++ b/src/any_agent/frameworks/any_agent.py
@@ -35,13 +35,27 @@ class AgentRunError(Exception):
     """Error that wraps underlying framework specific errors and carries spans."""
 
     _trace: AgentTrace
+    _original_exception: Exception
 
-    def __init__(self, trace: AgentTrace):
+    def __init__(self, trace: AgentTrace, original_exception: Exception):
         self._trace = trace
+        self._original_exception = original_exception
+        # Set the exception message to be the original exception's message
+        super().__init__(str(original_exception))
 
     @property
     def trace(self) -> AgentTrace:
         return self._trace
+
+    @property
+    def original_exception(self) -> Exception:
+        return self._original_exception
+
+    def __str__(self) -> str:
+        return str(self._original_exception)
+
+    def __repr__(self) -> str:
+        return f"AgentRunError({self._original_exception!r})"
 
 
 class AnyAgent(ABC):
@@ -206,7 +220,7 @@ class AnyAgent(ABC):
                     if instrumented_trace is not None:
                         trace = instrumented_trace
             trace.add_span(invoke_span)
-            raise AgentRunError(trace) from e
+            raise AgentRunError(trace, e)
 
         if instrumentation_enabled:
             async with self._lock:


### PR DESCRIPTION
Updated the AgentRunError class to accept and store the original exception, improving error handling. The string representation now reflects the original exception message for better debugging.

was:
<img width="1466" alt="Screenshot 2025-06-25 at 6 05 08 AM" src="https://github.com/user-attachments/assets/c73aefdc-356b-4719-b1a7-e71a8fd49a72" />


now:
<img width="1107" alt="Screenshot 2025-06-25 at 5 57 57 AM" src="https://github.com/user-attachments/assets/0d5b5eec-b63a-4d97-be4f-362d9db3a311" />
