### PR TITLE
Add missing typevar in LlamaIndex

### DIFF
--- a/src/any_agent/tracing/instrumentation/llama_index.py
+++ b/src/any_agent/tracing/instrumentation/llama_index.py
@@ -92,7 +92,7 @@ class _LlamaIndexInstrumentor:
         self._original_take_step = agent._agent.take_step
 
         async def wrap_take_step(
-            ctx: Context,
+            ctx: Context[Any],
             llm_input: list[ChatMessage],
             tools: Sequence[AsyncBaseTool],
             memory: BaseMemory,


### PR DESCRIPTION
The new llama-index-core version 0.12.44 seems to add a typevar to Context. This PR aligns the instrumenter with this change to avoid type checking issues.