### PR TITLE
Remove unused type ignore

### DIFF
--- a/src/any_agent/serving/server_mcp.py
+++ b/src/any_agent/serving/server_mcp.py
@@ -42,7 +42,7 @@ def _create_mcp_server_instance(agent: AnyAgent) -> MCPServer[Any]:
             )
         ]
 
-    @server.call_tool()  # type: ignore[no-untyped-call,misc]
+    @server.call_tool()  # type: ignore[misc]
     async def handle_call_tool(
         name: str, arguments: dict[str, Any]
     ) -> list[mcptypes.TextContent | mcptypes.ImageContent | mcptypes.EmbeddedResource]:


### PR DESCRIPTION
Apparently, the bump of `mcp` to 1.10.0 now causes one of the type ignore annotations to become unnecessary, breaking the lint. This PR removes the unused type ignore annotation.