### PR TITLE
Increase timeout for message sending in integration tests 🕒✨

### DIFF
--- a/src/any_agent/tools/a2a.py
+++ b/src/any_agent/tools/a2a.py
@@ -46,6 +46,13 @@ async def a2a_tool_async(
         msg = "You need to `pip install 'any-agent[a2a]'` to use this tool"
         raise ImportError(msg)
 
+    if http_kwargs is None:
+        http_kwargs = {}
+
+    # Default timeout in httpx is 5 seconds. For an agent response, the default should be more lenient.
+    if "timeout" not in http_kwargs:
+        http_kwargs["timeout"] = 30.0
+
     async with httpx.AsyncClient(follow_redirects=True) as resolver_client:
         a2a_agent_card: AgentCard = await (
             A2ACardResolver(httpx_client=resolver_client, base_url=url)

--- a/tests/integration/a2a/test_a2a_serve.py
+++ b/tests/integration/a2a/test_a2a_serve.py
@@ -42,7 +42,7 @@ async def test_serve_sync(test_port: int, a2a_test_helpers: A2ATestHelpers) -> N
             request = a2a_test_helpers.create_send_message_request(
                 text="What is an agent?"
             )
-            response = await client.send_message(request)
+            response = await client.send_message(request, http_kwargs={"timeout": 30.0})
             assert response is not None
     finally:
         proc.kill()
@@ -70,5 +70,5 @@ async def test_serve_async(test_port: int, a2a_test_helpers: A2ATestHelpers) -> 
             text="What is an agent?",
             message_id=uuid4().hex,
         )
-        response = await client.send_message(request)
+        response = await client.send_message(request, http_kwargs={"timeout": 30.0})
         assert response is not None

--- a/tests/integration/a2a/test_a2a_tool.py
+++ b/tests/integration/a2a/test_a2a_tool.py
@@ -12,7 +12,6 @@ from tests.integration.helpers import DEFAULT_MODEL_ID, wait_for_server
 
 from .conftest import (
     DATE_PROMPT,
-    DEFAULT_TIMEOUT,
     a2a_client_from_agent,
     assert_contains_current_date_info,
     get_datetime,
@@ -90,11 +89,7 @@ async def test_a2a_tool_async(agent_framework: AgentFramework) -> None:
             instructions="Use the available tools to obtain additional information to answer the query.",
             description="The orchestrator that can use other agents via tools using the A2A protocol.",
             model_id=DEFAULT_MODEL_ID,
-            tools=[
-                await a2a_tool_async(
-                    server_url, http_kwargs={"timeout": DEFAULT_TIMEOUT}
-                )
-            ],
+            tools=[await a2a_tool_async(server_url)],
             model_args=model_args,
         )
 
@@ -201,7 +196,6 @@ def test_a2a_tool_sync(agent_framework: AgentFramework) -> None:
             tools=[
                 a2a_tool(
                     f"http://localhost:{test_port}/{tool_agent_endpoint}",
-                    http_kwargs={"timeout": DEFAULT_TIMEOUT},
                 )
             ],
             model_id=DEFAULT_MODEL_ID,

--- a/tests/integration/a2a/test_a2a_tool_multiturn.py
+++ b/tests/integration/a2a/test_a2a_tool_multiturn.py
@@ -235,7 +235,7 @@ async def test_a2a_tool_multiturn() -> None:
             request_1 = SendMessageRequest(
                 id=str(uuid4()), params=MessageSendParams(**send_message_payload_1)
             )
-            response_1 = await client.send_message(request_1)
+            response_1 = await client.send_message(request_1, http_kwargs={"timeout": 30.0})
 
             assert response_1 is not None
             result = UserInfo.model_validate_json(
@@ -262,7 +262,7 @@ async def test_a2a_tool_multiturn() -> None:
             request_2 = SendMessageRequest(
                 id=str(uuid4()), params=MessageSendParams(**send_message_payload_2)
             )
-            response_2 = await client.send_message(request_2)
+            response_2 = await client.send_message(request_2, http_kwargs={"timeout": 30.0})
 
             assert response_2 is not None
             result = UserInfo.model_validate_json(
@@ -286,7 +286,7 @@ async def test_a2a_tool_multiturn() -> None:
             request_3 = SendMessageRequest(
                 id=str(uuid4()), params=MessageSendParams(**send_message_payload_3)
             )
-            response_3 = await client.send_message(request_3)
+            response_3 = await client.send_message(request_3, http_kwargs={"timeout": 30.0})
             assert response_3 is not None
             result = UserInfo.model_validate_json(
                 response_3.root.result.status.message.parts[0].root.text

--- a/tests/integration/a2a/test_a2a_tool_multiturn.py
+++ b/tests/integration/a2a/test_a2a_tool_multiturn.py
@@ -235,7 +235,9 @@ async def test_a2a_tool_multiturn() -> None:
             request_1 = SendMessageRequest(
                 id=str(uuid4()), params=MessageSendParams(**send_message_payload_1)
             )
-            response_1 = await client.send_message(request_1, http_kwargs={"timeout": 30.0})
+            response_1 = await client.send_message(
+                request_1, http_kwargs={"timeout": 30.0}
+            )
 
             assert response_1 is not None
             result = UserInfo.model_validate_json(
@@ -262,7 +264,9 @@ async def test_a2a_tool_multiturn() -> None:
             request_2 = SendMessageRequest(
                 id=str(uuid4()), params=MessageSendParams(**send_message_payload_2)
             )
-            response_2 = await client.send_message(request_2, http_kwargs={"timeout": 30.0})
+            response_2 = await client.send_message(
+                request_2, http_kwargs={"timeout": 30.0}
+            )
 
             assert response_2 is not None
             result = UserInfo.model_validate_json(
@@ -286,7 +290,9 @@ async def test_a2a_tool_multiturn() -> None:
             request_3 = SendMessageRequest(
                 id=str(uuid4()), params=MessageSendParams(**send_message_payload_3)
             )
-            response_3 = await client.send_message(request_3, http_kwargs={"timeout": 30.0})
+            response_3 = await client.send_message(
+                request_3, http_kwargs={"timeout": 30.0}
+            )
             assert response_3 is not None
             result = UserInfo.model_validate_json(
                 response_3.root.result.status.message.parts[0].root.text
@@ -338,7 +344,7 @@ async def test_a2a_tool_multiturn_async() -> None:
             model_id="gpt-4.1-nano",
             instructions="Use the available tools to obtain additional information to answer the query.",
             description="The orchestrator that can use other agents via tools using the A2A protocol.",
-            tools=[await a2a_tool_async(server_url, http_kwargs={"timeout": 10.0})],
+            tools=[await a2a_tool_async(server_url)],
             output_type=MainAgentAnswer,
             model_args={
                 "parallel_tool_calls": False  # to force it to talk to the agent one call at a time


### PR DESCRIPTION
Default httpx timeout is 5 seconds. Occasionally an agent takes longer than 5 seconds, so imo it's an unreasonable default for our use case.

This should help stabilize our integration tests too