### PR TITLE
Avoid import errors in Python 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,7 @@ extend-select = ["ALL"]
 "src/any_agent/evaluation/*" = ["D101", "D103", "D107"]  # TODO: Revisit when working on evaluation
 "src/any_agent/evaluation/evaluators/*" = ["D103", "D107"]
 "src/any_agent/frameworks/*" = ["D107", "D102"]
+"src/any_agent/serving/a2a/agent_executor.py" = ["E402", "D102"]  # Due to Python 3.11 compatibility
 "src/any_agent/tools/mcp/*" = ["D101"]
 "tests/*" = ["D"]
 "*.ipynb" = ["T201"]

--- a/src/any_agent/serving/a2a/agent_executor.py
+++ b/src/any_agent/serving/a2a/agent_executor.py
@@ -1,4 +1,20 @@
-from typing import TYPE_CHECKING, override
+import sys
+
+PYTHONEGT312 = sys.version_info >= (3, 12)
+
+from typing import TYPE_CHECKING
+
+if PYTHONEGT312:
+    from typing import override
+else:
+    from collections.abc import Callable
+    from typing import Any, TypeVar
+
+    F = TypeVar("F", bound=Callable[..., Any])
+
+    def override(func: F, /) -> F:  # noqa: D103
+        return func
+
 
 from a2a.server.agent_execution import AgentExecutor, RequestContext
 from a2a.server.events import EventQueue

--- a/src/any_agent/serving/a2a/agent_executor.py
+++ b/src/any_agent/serving/a2a/agent_executor.py
@@ -7,11 +7,22 @@ from typing import TYPE_CHECKING
 if PYTHONEGT312:
     from typing import override
 else:
+    # Fix for Python 3.11
+    # We will define a "noop" decorator that
+    # returns the same function
+    # Trying to modify decorators in place depending
+    # on the python version is much more cumbersome
     from collections.abc import Callable
     from typing import Any, TypeVar
 
+    # For any function that takes some params
+    # and returns whatever (upper bound)....
     F = TypeVar("F", bound=Callable[..., Any])
 
+    # ...we ensure that the decorator returns a function
+    # with the same type constraints (basically,
+    # because it's the same function), and that
+    # the decorator doesn't require any extra info
     def override(func: F, /) -> F:  # noqa: D103
         return func
 


### PR DESCRIPTION
The `typing.override` decorator is not available in python 3.11. A noop decorator is provided instead for that version.

Closes #565 