### PR TITLE
Upgrade to support new A2A Protocol

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,7 @@ extend-select = ["ALL"]
 "src/any_agent/evaluation/evaluators/*" = ["D103", "D107"]
 "src/any_agent/frameworks/*" = ["D107", "D102"]
 "src/any_agent/tools/mcp/*" = ["D101"]
+"src/any_agent/tools/a2a.py" = ["UP045"]  # Use `X | Y` for type unions - disabled for Google ADK compatibility
 "tests/*" = ["D"]
 "*.ipynb" = ["T201"]
 

--- a/src/any_agent/serving/a2a/config_a2a.py
+++ b/src/any_agent/serving/a2a/config_a2a.py
@@ -53,7 +53,7 @@ class A2AServingConfig(BaseModel):
                     description="Search the web for information"
                 )
             ],
-            task_timeout_minutes=15
+            context_timeout_minutes=15
         )
 
     """
@@ -80,7 +80,7 @@ class A2AServingConfig(BaseModel):
 
     version: str = "0.1.0"
 
-    task_timeout_minutes: int = 10
+    context_timeout_minutes: int = 10
     """Task timeout in minutes. Tasks will be cleaned up after this period of inactivity."""
 
     history_formatter: HistoryFormatter = default_history_formatter

--- a/src/any_agent/serving/a2a/server_a2a.py
+++ b/src/any_agent/serving/a2a/server_a2a.py
@@ -10,7 +10,7 @@ from a2a.server.tasks import InMemoryTaskStore
 from starlette.applications import Starlette
 from starlette.routing import Mount
 
-from any_agent.serving.a2a.task_manager import TaskManager
+from any_agent.serving.a2a.context_manager import ContextManager
 from any_agent.serving.server_handle import ServerHandle
 from any_agent.utils import run_async_in_sync
 
@@ -31,7 +31,7 @@ def _get_a2a_app(
     agent = prepare_agent_for_a2a(agent)
 
     agent_card = _get_agent_card(agent, serving_config)
-    task_manager = TaskManager(serving_config)
+    task_manager = ContextManager(serving_config)
 
     request_handler = DefaultRequestHandler(
         agent_executor=AnyAgentExecutor(agent, task_manager),
@@ -47,7 +47,7 @@ async def _get_a2a_app_async(
     agent = await prepare_agent_for_a2a_async(agent)
 
     agent_card = _get_agent_card(agent, serving_config)
-    task_manager = TaskManager(serving_config)
+    task_manager = ContextManager(serving_config)
 
     request_handler = DefaultRequestHandler(
         agent_executor=AnyAgentExecutor(agent, task_manager),

--- a/src/any_agent/tools/a2a.py
+++ b/src/any_agent/tools/a2a.py
@@ -29,7 +29,7 @@ with suppress(ImportError):
 
 async def a2a_tool_async(
     url: str, toolname: str | None = None, http_kwargs: dict[str, Any] | None = None
-) -> Callable[[str], Coroutine[Any, Any, str]]:
+) -> Callable[[str], Coroutine[Any, Any, dict[str, Any]]]:
     """Perform a query using A2A to another agent.
 
     Args:
@@ -58,7 +58,13 @@ async def a2a_tool_async(
             A2ACardResolver(httpx_client=resolver_client, base_url=url)
         ).get_agent_card()
 
-    async def _send_query(query: str, task_id: str = str(uuid4())) -> str:
+    # NOTE: Use Optional[T] instead of T | None syntax throughout this module.
+    # Google ADK's _parse_schema_from_parameter function has compatibility
+    # with the traditional Optional[T] syntax for automatic function calling.
+    # Using T | None syntax causes"Failed to parse the parameter ... for automatic function calling"
+    async def _send_query(
+        query: str, task_id: str | None = None, context_id: str | None = None
+    ) -> dict[str, Any]:
         async with httpx.AsyncClient(follow_redirects=True) as query_client:
             client = A2AClient(httpx_client=query_client, agent_card=a2a_agent_card)
             send_message_payload = SendMessageRequest(
@@ -70,6 +76,7 @@ async def a2a_tool_async(
                         # the id is not currently tracked
                         messageId=str(uuid4().hex),
                         taskId=task_id,
+                        contextId=context_id,
                     )
                 ),
             )
@@ -86,20 +93,27 @@ async def a2a_tool_async(
                 raise ValueError(msg)
 
             if hasattr(response.root, "error"):
-                response_str = ""
-                response_str += f"Error: {response.root.error.message}\n\n"
-                response_str += f"Code: {response.root.error.code}\n\n"
-                response_str += f"Data: {response.root.error.data}\n\n"
+                response_dict = {
+                    "error": response.root.error.message,
+                    "code": response.root.error.code,
+                    "data": response.root.error.data,
+                }
             elif hasattr(response.root, "result"):
-                response_str = ""
-                response_str += f"Status: {response.root.result.status.state}\n\n"
-                response_str += f"""Message: {" ".join([part.root.text for part in response.root.result.status.message.parts if part.root.kind == "text"])}\n\n"""
-                response_str += (
-                    f"TaskId: {response.root.result.status.message.taskId}\n\n"
-                )
-                response_str += (
-                    f"Timestamp: {response.root.result.status.timestamp}\n\n"
-                )
+                response_dict = {
+                    "task_id": response.root.result.status.message.taskId,
+                    "context_id": response.root.result.status.message.contextId,
+                    "timestamp": response.root.result.status.timestamp,
+                    "status": response.root.result.status.state,
+                    "message": {
+                        " ".join(
+                            [
+                                part.root.text
+                                for part in response.root.result.status.message.parts
+                                if part.root.kind == "text"
+                            ]
+                        )
+                    },
+                }
             else:
                 msg = (
                     "The A2A agent did not return a error or a result. Are you using an A2A agent not managed by any-agent? "
@@ -107,7 +121,7 @@ async def a2a_tool_async(
                 )
                 raise ValueError(msg)
 
-            return response_str
+            return response_dict
 
     new_name = toolname or a2a_agent_card.name
     new_name = re.sub(r"\s+", "_", new_name.strip())
@@ -118,11 +132,19 @@ async def a2a_tool_async(
         Agent description: {a2a_agent_card.description}
 
         Args:
-            query (str): The query to perform.
-            task_id (str): The task id to use for the conversation. Defaults to a new uuid. If you want to continue the conversation, you should provide the same task id that you received in a previous response.
+            query (str): The query to send to the agent.
+            task_id (str, optional): Task ID for continuing an incomplete task. Use the same
+                task_id from a previous response with TaskState.input_required to resume the task.
+            context_id (str, optional): Context ID for conversation continuity. Provides the
+                agent with conversation history. Omit to start a fresh conversation.
 
         Returns:
-            The result from the A2A agent, encoded as a json string.
+            dict: Response from the A2A agent containing:
+                - For successful responses: task_id, context_id, timestamp, status, and message
+                - For errors: error message, code, and data
+
+        Note:
+            If TaskState is terminal (completed/failed), do not reuse the same task_id.
     """
     return _send_query
 

--- a/tests/integration/a2a/test_a2a_tool_multiturn.py
+++ b/tests/integration/a2a/test_a2a_tool_multiturn.py
@@ -273,8 +273,8 @@ async def test_a2a_tool_multiturn() -> None:
 
             assert response_2 is not None
             # if the response is JSONRPCErrorResposne, log and raise an error
-            if hasattr(response_1.root, "error"):
-                msg = f"Error: {response_1.root.error.message}, Code: {response_1.root.error.code}, Data: {response_1.root.error.data}"
+            if hasattr(response_2.root, "error"):
+                msg = f"Error: {response_2.root.error.message}, Code: {response_2.root.error.code}, Data: {response_2.root.error.data}"
                 raise RuntimeError(msg)
             result = UserInfo.model_validate_json(
                 response_2.root.result.status.message.parts[0].root.text
@@ -290,8 +290,8 @@ async def test_a2a_tool_multiturn() -> None:
                     "role": "user",
                     "parts": [{"kind": "text", "text": THIRD_TURN_PROMPT}],
                     "messageId": str(uuid4()),
-                    "contextId": response_1.root.result.contextId,  # Same context to continue conversation
-                    "taskId": response_1.root.result.id,
+                    "contextId": response_2.root.result.contextId,  # Same context to continue conversation
+                    "taskId": response_2.root.result.id,
                 },
             }
             request_3 = SendMessageRequest(
@@ -302,8 +302,8 @@ async def test_a2a_tool_multiturn() -> None:
             )
             assert response_3 is not None
             # if the response is JSONRPCErrorResposne, log and raise an error
-            if hasattr(response_1.root, "error"):
-                msg = f"Error: {response_1.root.error.message}, Code: {response_1.root.error.code}, Data: {response_1.root.error.data}"
+            if hasattr(response_3.root, "error"):
+                msg = f"Error: {response_3.root.error.message}, Code: {response_3.root.error.code}, Data: {response_3.root.error.data}"
                 raise RuntimeError(msg)
             result = UserInfo.model_validate_json(
                 response_3.root.result.status.message.parts[0].root.text

--- a/tests/integration/a2a/test_a2a_tool_multiturn.py
+++ b/tests/integration/a2a/test_a2a_tool_multiturn.py
@@ -150,7 +150,7 @@ class MockConversationAgent(TinyAgent):
         spans = []
         spans.append(
             AgentSpan(
-                name="call_llm gpt-4o-mini",
+                name="call_llm gpt-4.1-nano",
                 kind=SpanKind.INTERNAL,
                 status=Status(),
                 context=SpanContext(span_id=123),
@@ -185,7 +185,7 @@ async def test_a2a_tool_multiturn() -> None:
 
     # Create a mock agent that simulates multi-turn conversation
     config = AgentConfig(
-        model_id="gpt-4o-mini",  # Using real model ID but will be mocked
+        model_id="gpt-4.1-nano",  # Using real model ID but will be mocked
         instructions=(
             "You are a helpful assistant that remembers our conversation. "
             "When asked about previous information, reference what was said earlier. "
@@ -201,7 +201,7 @@ async def test_a2a_tool_multiturn() -> None:
     # Configure session management with short timeout for testing
     serving_config = A2AServingConfig(
         port=0,
-        task_timeout_minutes=2,  # Short timeout for testing
+        context_timeout_minutes=2,  # Short timeout for testing
     )
 
     server_handle = await agent.serve_async(serving_config=serving_config)
@@ -240,6 +240,10 @@ async def test_a2a_tool_multiturn() -> None:
             )
 
             assert response_1 is not None
+            # if the response is JSONRPCErrorResposne, log and raise an error
+            if hasattr(response_1.root, "error"):
+                msg = f"Error: {response_1.root.error.message}, Code: {response_1.root.error.code}, Data: {response_1.root.error.data}"
+                raise RuntimeError(msg)
             result = UserInfo.model_validate_json(
                 response_1.root.result.status.message.parts[0].root.text
             )
@@ -257,7 +261,6 @@ async def test_a2a_tool_multiturn() -> None:
                     ],
                     "messageId": str(uuid4()),
                     "contextId": response_1.root.result.contextId,  # Same context to continue conversation
-                    "taskId": response_1.root.result.id,
                 },
             }
 
@@ -269,6 +272,10 @@ async def test_a2a_tool_multiturn() -> None:
             )
 
             assert response_2 is not None
+            # if the response is JSONRPCErrorResposne, log and raise an error
+            if hasattr(response_1.root, "error"):
+                msg = f"Error: {response_1.root.error.message}, Code: {response_1.root.error.code}, Data: {response_1.root.error.data}"
+                raise RuntimeError(msg)
             result = UserInfo.model_validate_json(
                 response_2.root.result.status.message.parts[0].root.text
             )
@@ -294,6 +301,10 @@ async def test_a2a_tool_multiturn() -> None:
                 request_3, http_kwargs={"timeout": 30.0}
             )
             assert response_3 is not None
+            # if the response is JSONRPCErrorResposne, log and raise an error
+            if hasattr(response_1.root, "error"):
+                msg = f"Error: {response_1.root.error.message}, Code: {response_1.root.error.code}, Data: {response_1.root.error.data}"
+                raise RuntimeError(msg)
             result = UserInfo.model_validate_json(
                 response_3.root.result.status.message.parts[0].root.text
             )
@@ -310,7 +321,7 @@ async def test_a2a_tool_multiturn_async() -> None:
 
     # Create a mock agent that simulates multi-turn conversation
     config = AgentConfig(
-        model_id="gpt-4o-mini",  # Using real model ID but will be mocked
+        model_id="gpt-4.1-nano",  # Using real model ID but will be mocked
         instructions=(
             "You are a helpful assistant that remembers our conversation. "
             "When asked about previous information, reference what was said earlier. "
@@ -327,7 +338,7 @@ async def test_a2a_tool_multiturn_async() -> None:
     # Configure session management with short timeout for testing
     serving_config = A2AServingConfig(
         port=0,
-        task_timeout_minutes=2,  # Short timeout for testing
+        context_timeout_minutes=2,  # Short timeout for testing
     )
 
     server_handle = await agent.serve_async(serving_config=serving_config)
@@ -343,7 +354,6 @@ async def test_a2a_tool_multiturn_async() -> None:
         main_agent_cfg = AgentConfig(
             model_id="gpt-4.1-nano",
             instructions="Use the available tools to obtain additional information to answer the query.",
-            description="The orchestrator that can use other agents via tools using the A2A protocol.",
             tools=[await a2a_tool_async(server_url)],
             output_type=MainAgentAnswer,
             model_args={
@@ -358,11 +368,10 @@ async def test_a2a_tool_multiturn_async() -> None:
         prompt = f"""
         Please talk to the structured UserInfo agent and interact with it. You'll contact it to ask three questions. Say the exact words from the prompt in your query to the agent.
 
-        1. {FIRST_TURN_PROMPT}
-        2. {SECOND_TURN_PROMPT}
-        3. {THIRD_TURN_PROMPT}
+        1. {FIRST_TURN_PROMPT}. Provide neither the context id nor the task id.
+        2. {SECOND_TURN_PROMPT}. Provide the context id but omit the task id.
+        3. {THIRD_TURN_PROMPT}. Provide both the context id and the task id.
 
-        Make sure you appropriately continue the conversation by providing it with the task id if you want to continue the conversation.
         """
 
         agent_trace = await main_agent.run_async(prompt)


### PR DESCRIPTION
* Save agent convo history under the "context id" not task. Now that a2a has upgraded their spec I now understand that task is just for managing whether a agent completed the task, it's not supposed to manage conversation history. The new version of the a2a spec enforces that design, which is what motivates this change
* When calling an agent as a tool, now the agent has the option to specify either task or context ids.
* A2A tool now responds with a dict, not a string. This maps better with the way that outputs are logged and managed