### PR TITLE
fix: llamaindex should ask for usage stats explicitly

### DIFF
--- a/src/any_agent/frameworks/llama_index.py
+++ b/src/any_agent/frameworks/llama_index.py
@@ -44,13 +44,17 @@ class LlamaIndexAgent(AnyAgent):
     def _get_model(self, agent_config: AgentConfig) -> "LLM":
         """Get the model configuration for a llama_index agent."""
         model_type = agent_config.model_type or DEFAULT_MODEL_TYPE
+        additional_kwargs = agent_config.model_args or {}
+        additional_kwargs["stream_options"] = {
+            "include_usage": True
+        }  # Needed so that we get usage stats
         return cast(
             "LLM",
             model_type(
                 model=agent_config.model_id,
                 api_key=agent_config.api_key,
                 api_base=agent_config.api_base,
-                additional_kwargs=agent_config.model_args or {},  # type: ignore[arg-type]
+                additional_kwargs=additional_kwargs,  # type: ignore[arg-type]
             ),
         )
 

--- a/tests/unit/frameworks/test_llama_index.py
+++ b/tests/unit/frameworks/test_llama_index.py
@@ -30,7 +30,9 @@ def test_load_llama_index_agent_default() -> None:
             model="gemini/gemini-2.0-flash",
             api_key=None,
             api_base=None,
-            additional_kwargs={},
+            additional_kwargs={
+                "stream_options": {"include_usage": True},
+            },
         )
         create_mock.assert_called_once_with(
             name="any_agent",


### PR DESCRIPTION
When switching to Mistral I found that by default, usage tokens are not included in the LiteLLM api except for OpenAI. This PR explicitly sets the request for usage to enable other providers.