### PR TITLE
fix: isolate completion_params

### DIFF
--- a/src/any_agent/frameworks/tinyagent.py
+++ b/src/any_agent/frameworks/tinyagent.py
@@ -180,10 +180,11 @@ class TinyAgent(AnyAgent):
 
         num_of_turns = 0
         max_turns = kwargs.get("max_turns", DEFAULT_MAX_NUM_TURNS)
+        completion_params = self.completion_params.copy()
 
         while num_of_turns < max_turns:
-            self.completion_params["messages"] = messages
-            response = await self.call_model(**self.completion_params)
+            completion_params["messages"] = messages
+            response = await self.call_model(**completion_params)
 
             message: LiteLLMMessage = response.choices[0].message  # type: ignore[union-attr]
 
@@ -225,12 +226,12 @@ class TinyAgent(AnyAgent):
                         "content": f"Please conform your output to the following schema: {self.config.output_type.model_json_schema()}.",
                     }
                     messages.append(structured_output_message)
-                    self.completion_params["messages"] = messages
+                    completion_params["messages"] = messages
                     if supports_response_schema(model=self.config.model_id):
-                        self.completion_params["response_format"] = (
+                        completion_params["response_format"] = (
                             self.config.output_type
                         )
-                    response = await litellm.acompletion(**self.completion_params)
+                    response = await litellm.acompletion(**completion_params)
                     return self.config.output_type.model_validate_json(
                         response.choices[0].message["content"]  # type: ignore[union-attr]
                     )

--- a/src/any_agent/frameworks/tinyagent.py
+++ b/src/any_agent/frameworks/tinyagent.py
@@ -228,9 +228,7 @@ class TinyAgent(AnyAgent):
                     messages.append(structured_output_message)
                     completion_params["messages"] = messages
                     if supports_response_schema(model=self.config.model_id):
-                        completion_params["response_format"] = (
-                            self.config.output_type
-                        )
+                        completion_params["response_format"] = self.config.output_type
                     completion_params["tool_choice"] = "none"
                     response = await litellm.acompletion(**completion_params)
                     return self.config.output_type.model_validate_json(

--- a/tests/unit/frameworks/test_tinyagent.py
+++ b/tests/unit/frameworks/test_tinyagent.py
@@ -1,9 +1,17 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic import BaseModel
 
 from any_agent import AgentConfig, AgentFramework, AnyAgent
 from any_agent.frameworks.tinyagent import TinyAgent, ToolExecutor
+
+
+class SampleOutput(BaseModel):
+    """Test output model for structured output testing."""
+
+    answer: str
+    confidence: float
 
 
 async def sample_tool_function(arg1: int, arg2: str) -> str:
@@ -69,3 +77,96 @@ def test_run_tinyagent_agent_custom_args() -> None:
 
         # Assert that the result contains the expected content
         assert output == result.final_output
+
+
+def test_output_type_completion_params_isolation() -> None:
+    """Test that completion_params are not polluted between calls when using output_type."""
+    # Create agent with output_type
+    config = AgentConfig(model_id="gpt-4o", output_type=SampleOutput)
+    agent = AnyAgent.create(AgentFramework.TINYAGENT, config)
+    original_completion_params = agent.completion_params.copy()
+
+    with patch(
+        "any_agent.frameworks.tinyagent.litellm.acompletion"
+    ) as mock_acompletion:
+        # Mock responses for the first run (2 calls: regular + structured output)
+        mock_response1 = MagicMock()
+        mock_message1 = MagicMock()
+        mock_message1.content = "First response"
+        mock_message1.tool_calls = []
+        mock_message1.model_dump.return_value = {
+            "content": "First response",
+            "role": "assistant",
+            "tool_calls": None,
+            "function_call": None,
+            "annotations": [],
+        }
+        mock_response1.choices = [MagicMock(message=mock_message1)]
+
+        # Mock response for the structured output call
+        mock_response_structured = MagicMock()
+        mock_message_structured = MagicMock()
+        mock_message_structured.content = (
+            '{"answer": "First response", "confidence": 0.9}'
+        )
+        mock_message_structured.tool_calls = []
+        mock_message_structured.model_dump.return_value = {
+            "content": '{"answer": "First response", "confidence": 0.9}',
+            "role": "assistant",
+            "tool_calls": None,
+            "function_call": None,
+            "annotations": [],
+        }
+        # Configure the mock to return the content string when accessed as dict
+        mock_message_structured.__getitem__.return_value = (
+            '{"answer": "First response", "confidence": 0.9}'
+        )
+        mock_response_structured.choices = [MagicMock(message=mock_message_structured)]
+
+        # Mock responses for the second run (2 calls: regular + structured output)
+        mock_response2 = MagicMock()
+        mock_message2 = MagicMock()
+        mock_message2.content = "Second response"
+        mock_message2.tool_calls = []
+        mock_message2.model_dump.return_value = {
+            "content": "Second response",
+            "role": "assistant",
+            "tool_calls": None,
+            "function_call": None,
+            "annotations": [],
+        }
+        mock_response2.choices = [MagicMock(message=mock_message2)]
+
+        mock_response_structured2 = MagicMock()
+        mock_message_structured2 = MagicMock()
+        mock_message_structured2.content = (
+            '{"answer": "Second response", "confidence": 0.95}'
+        )
+        mock_message_structured2.tool_calls = []
+        mock_message_structured2.model_dump.return_value = {
+            "content": '{"answer": "Second response", "confidence": 0.95}',
+            "role": "assistant",
+            "tool_calls": None,
+            "function_call": None,
+            "annotations": [],
+        }
+        # Configure the mock to return the content string when accessed as dict
+        mock_message_structured2.__getitem__.return_value = (
+            '{"answer": "Second response", "confidence": 0.95}'
+        )
+        mock_response_structured2.choices = [
+            MagicMock(message=mock_message_structured2)
+        ]
+
+        # Make acompletion return responses in order: first run (2 calls), then second run (2 calls)
+        mock_acompletion.side_effect = [
+            mock_response1,  # First run, first call
+            mock_response_structured,  # First run, structured output call
+            mock_response2,  # Second run, first call
+            mock_response_structured2,  # Second run, structured output call
+        ]
+
+        # First call - should trigger structured output handling
+        agent.run("First question")
+
+        assert agent.completion_params == original_completion_params

--- a/tests/unit/frameworks/test_tinyagent.py
+++ b/tests/unit/frameworks/test_tinyagent.py
@@ -110,10 +110,6 @@ def test_output_type_completion_params_isolation() -> None:
             create_mock_response(
                 '{"answer": "First response", "confidence": 0.9}', True
             ),  # First run, structured
-            create_mock_response("Second response"),  # Second run, regular call
-            create_mock_response(
-                '{"answer": "Second response", "confidence": 0.95}', True
-            ),  # Second run, structured
         ]
 
         # First call - should trigger structured output handling


### PR DESCRIPTION
Each time run_async is called, it shouldn't inherit any changes made by other run_async calls.