### PR TITLE
docs: Reorder Agents-As-Tools 

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ print(agent_trace)
 
 
 > [!TIP]
-> Multi-agent can be implemented today using the A2A protocol (see [A2A docs](https://mozilla-ai.github.io/any-agent/serving/))
+> Multi-agent can be implemented [using Agents-As-Tools](https://mozilla-ai.github.io/any-agent/agents/tools/#using-agents-as-tools)
 > and will be also supported with Agent-As-Tools (follow progress at https://github.com/mozilla-ai/any-agent/issues/382)
 
 ## Cookbooks

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -34,7 +34,7 @@ agent = AnyAgent.create(
     As stated before, carefully consider whether you need to adopt this pattern to
     solve the task.
 
-Multi-agent can be implemented today using the A2A protocol (see [A2A docs](https://mozilla-ai.github.io/any-agent/serving/)) and will be also supported with Agent-As-Tools (follow progress at https://github.com/mozilla-ai/any-agent/issues/382).
+Multi-Agent systems can be implemented [using Agent-As-Tools](./tools.md#using-agents-as-tools).
 
 ### Framework Specific Arguments
 

--- a/docs/agents/tools.md
+++ b/docs/agents/tools.md
@@ -79,7 +79,7 @@ To directly use one agent as a tool for another agent, `any-agent` provides 3 di
 
 The agent to be used as a tool can be defined as usual:
 
-```python
+```py
 from any_agent import AgentConfig, AnyAgent
 from any_agent.tools import search_web
 
@@ -99,7 +99,7 @@ You can then choose to wrap the agent using different approaches:
 
 === "Agent as Callable"
 
-    ```python
+    ```py
     async def google_agent_as_tool(query: str) -> str:
         agent_trace = await google_agent.run_async(prompt=query)
         return str(agent_trace.final_output)
@@ -109,7 +109,7 @@ You can then choose to wrap the agent using different approaches:
 
 === "Agent as MCP"
 
-    ```python
+    ```py
     from any_agent.config import MCPSse
     from any_agent.serving import MCPServingConfig
 
@@ -122,7 +122,7 @@ You can then choose to wrap the agent using different approaches:
 
 === "Agent as A2A"
 
-    ```python
+    ```py
     from any_agent.serving import A2AServingConfig
     from any_agent.tools import a2a_tool_async
 
@@ -135,7 +135,7 @@ You can then choose to wrap the agent using different approaches:
 
 Finally, regardless of the option chosen above, you can pass the agent as a tool to another agent:
 
-```python
+```py
 main_agent = await AnyAgent.create_async(
     "tinyagent",
     AgentConfig(

--- a/docs/agents/tools.md
+++ b/docs/agents/tools.md
@@ -26,53 +26,9 @@ main_agent = AgentConfig(
 )
 ```
 
-### Using an Agent as a tool
-
-If you would like to directly use one agent as a tool for another agent, the simplest way to do this is to wrap
-the first agent inside of a callable and then provide that callable to the second agent as a tool.
-
-```python
-import asyncio
-from any_agent import AgentConfig, AgentFramework, AnyAgent, AgentTrace
-from any_agent.tools import search_web
-
-async def main():
-    google_agent = await AnyAgent.create_async(
-        "google",
-        AgentConfig(
-            name="google_expert",
-            model_id="gpt-4.1-nano",
-            instructions="Use the available tools to answer questions about the Google ADK",
-            description="An agent that can answer questions about the Google Agents Development Kit (ADK).",
-            tools=[search_web]
-        )
-    )
-
-    async def google_agent_as_tool(query: str) -> str:
-        agent_trace = await google_agent.run_async(query)
-        return agent_trace.final_output
-
-    # Callables require a docstring so that they can be properly provided as a tool
-    google_agent_as_tool.__doc__ = google_agent.config.description
-
-    main_agent = await AnyAgent.create_async(
-        "tinyagent",
-        AgentConfig(
-            name="main_agent",
-            model_id="gpt-4.1-nano",
-            instructions="Use the available tools to obtain additional information to answer the query.",
-            tools=[google_agent_as_tool],
-        )
-    )
-    # .... Continue with logic to run and handle return values.
-asyncio.run(main())
-```
-
-Since the agent will use the function documentation to decide whether it is appropriate to call the tool, we have copied the agent description into the function `__doc__` field. A normal docstring would also work.
-
-Other options to create tools from remote agents include using the MCP (SSE transport) or A2A protocols, as detailed in the following sections.
 
 ## MCP
+
 MCP can either be run locally ([MCPStdio][any_agent.config.MCPStdio]) or you can connect to an MCP that is running elsewhere ([MCPSse][any_agent.config.MCPSse]).
 
 !!! tip
@@ -117,84 +73,76 @@ MCP can either be run locally ([MCPStdio][any_agent.config.MCPStdio]) or you can
     )
     ```
 
-## A2A tools
+## Using Agents-As-Tools
 
-!!! tip
+To directly use one agent as a tool for another agent, `any-agent` provides 3 different approaches:
 
-    More information about serving agents over the A2A protocol can be found [here](../serving.md)
-
-`any-agent` provides a tool to wrap a connection to another another agent served over the A2A protocol, by invoking the `any_agent.tools.a2a_tool` or `any_agent.tools.a2a_tool_async` function, for example:
+The agent to be used as a tool can be defined as usual:
 
 ```python
-import asyncio
-from any_agent.tools import a2a_tool_async
+from any_agent import AgentConfig, AnyAgent
+from any_agent.tools import search_web
 
-async def main():
-    some_agent_tool = await a2a_tool_async("http://example.net:10000/some_agent")
-
-    agent_cfg = AgentConfig(
-        instructions="Use the available tools to obtain additional information to answer the query.",
-        description="A sample agent.",
-        model_id="gpt-4o-mini",
-        tools=[some_agent_tool],
+google_agent = await AnyAgent.create_async(
+    "google",
+    AgentConfig(
+        name="google_expert",
+        model_id="gpt-4.1-nano",
+        instructions="Use the available tools to answer questions about the Google ADK",
+        description="An agent that can answer questions about the Google Agents Development Kit (ADK).",
+        tools=[search_web]
     )
-asyncio.run(main())
+)
 ```
 
-The tool description is derived from the agent card, which is retrieved when this function is invoked. View the docstring in [a2a_tool_async][any_agent.tools.a2a_tool_async] or [a2a_tool][any_agent.tools.a2a_tool] for a description of the arguments available.
+You can then choose to wrap the agent using different approaches:
 
-## Agents-as-tools comparison
-
-The following chart summarizes the different methods to set up an agent as a tool: wrapping it as a callable, serving it via MCP, and serving it via A2A:
-
-=== "Agent as callable"
+=== "Agent as Callable"
 
     ```python
-    async def callable_agent_as_tool(query: str) -> str:
-        out = await callable_agent.run_async(prompt=query)
-        return str(out.final_output)
+    async def google_agent_as_tool(query: str) -> str:
+        agent_trace = await google_agent.run_async(prompt=query)
+        return str(agent_trace.final_output)
 
-    callable_agent_as_tool.__doc__ = callable_agent.config.description
-
-    main_agent_cfg = AgentConfig(
-        tools=[
-            callable_agent_as_tool
-        ],
-        ...
-    )
-
+    google_agent_as_tool.__doc__ = google_agent.config.description
     ```
 
 === "Agent as MCP"
 
     ```python
-    mcp_handle = mcp_agent.serve_async(MCPServingConfig(port=sse_port,endpoint=sse_endpoint))
+    from any_agent.config import MCPSse
+    from any_agent.serving import MCPServingConfig
 
-    main_agent = AgentConfig(
-        tools=[
-            MCPSse(
-                url=f"http://localhost:{sse_port}/{sse_endpoint}"
-            ),
-        ],
-        ...
-    )
+    mcp_handle = await google_agent.serve_async(
+        MCPServingConfig(port=5001, endpoint="/google-agent"))
+
+    google_agent_as_tool = MCPSse(
+        url="http://localhost:5001/google-agent/sse")
     ```
 
 === "Agent as A2A"
 
     ```python
-    a2a_agent = AnyAgent.create(
-        ...
-    )
+    from any_agent.serving import A2AServingConfig
+    from any_agent.tools import a2a_tool_async
 
-    a2a_handle = a2a_agent.serve_async(A2AServingConfig(port=a2a_port,endpoint=a2a_endpoint))
+    a2a_handle = await google_agent.serve_async(
+        A2AServingConfig(port=5001, endpoint="/google-agent"))
 
-    a2a_agent_tool = await a2a_tool_async(f"http://localhost:{a2a_port}/{a2a_endpoint}")
-
-    agent_cfg = AgentConfig(
-        tools=[
-            a2a_agent_tool
-        ],
-    )
-
+    google_agent_as_tool = await a2a_tool_async(
+        url="http://localhost:5001/google-agent")
     ```
+
+Finally, regardless of the option chosen above, you can pass the agent as a tool to another agent:
+
+```python
+main_agent = await AnyAgent.create_async(
+    "tinyagent",
+    AgentConfig(
+        name="main_agent",
+        model_id="gpt-4.1-nano",
+        instructions="Use the available tools to obtain additional information to answer the query.",
+        tools=[google_agent_as_tool],
+    )
+)
+```


### PR DESCRIPTION
Consolidate into a single section that share the same use case and can be linked.