### PR TITLE
feat: pin a2a sdk version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ smolagents = [
 ]
 
 a2a = [
-  "a2a-sdk>=0.2.8",
+  "a2a-sdk==0.2.10",
   "httpx",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ smolagents = [
 ]
 
 a2a = [
-  "a2a-sdk==0.2.10",
+  "a2a-sdk>=0.2.8, <=0.2.10",
   "httpx",
 ]
 


### PR DESCRIPTION
As discussed via slack: The Google A2A Python SDK and API is still in development and has put breaking changes into patch versions a few times. I'd like to switch over to pin the a2a version and use dependabot to carefully manged the version range until the a2a sdk gets more stable.