### PR TITLE
feat: remove sync serving option

### DIFF
--- a/docs/cookbook/serve_a2a.ipynb
+++ b/docs/cookbook/serve_a2a.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Serve an Agent with A2A\n",
     "\n",
-    "Once you've built an agent, a common question might be: \"how do I let other developers/applications access it?\". Enter the [A2A](https://github.com/google-a2a/A2A) protocol by Google! A2A is \"An open protocol enabling communication and interoperability between opaque agentic applications\". Any-Agent provides support for serving an agent over A2A, as simple as calling `agent.serve()`. In this tutorial, we'll build and serve an agent using any-agent, and show how you can serve and interact with it via the A2A protocol.\n",
+    "Once you've built an agent, a common question might be: \"how do I let other developers/applications access it?\". Enter the [A2A](https://github.com/google-a2a/A2A) protocol by Google! A2A is \"An open protocol enabling communication and interoperability between opaque agentic applications\". Any-Agent provides support for serving an agent over A2A, as simple as calling `await agent.serve_async()`. In this tutorial, we'll build and serve an agent using any-agent, and show how you can serve and interact with it via the A2A protocol.\n",
     "\n",
     "<img src=\"/images/serve_a2a.png\" alt=\"\" style=\"max-width: 500px; height: auto;\">\n",
     "\n",

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -10,7 +10,41 @@ these protocols, as explaining them is out of the scope of this page.
 
 In order to use A2A serving, you must first install the 'a2a' extra: `pip install 'any-agent[a2a]'`
 
-You can configure and serve an agent using the [`A2AServingConfig`][any_agent.serving.A2AServingConfig] and the [`AnyAgent.serve`][any_agent.AnyAgent.serve] or [`AnyAgent.serve_async`][any_agent.AnyAgent.serve_async] method.
+You can configure and serve an agent using the [`A2AServingConfig`][any_agent.serving.A2AServingConfig] and the [`AnyAgent.serve_async`][any_agent.AnyAgent.serve_async] method.
+
+## Running Async Servers in Sync Environments
+
+Since `any-agent` uses async/await patterns for better performance and resource management, the serving functions are async by default. However, you can easily run async servers in sync environments using Python's `asyncio` utilities:
+
+### Using `asyncio.run()`
+
+The simplest approach is to wrap your async code in `asyncio.run()`:
+
+```python
+import asyncio
+from any_agent import AgentConfig, AnyAgent
+from any_agent.serving import A2AServingConfig
+
+async def main():
+    agent = await AnyAgent.create_async(
+        "tinyagent",
+        AgentConfig(
+            name="my_agent",
+            model_id="mistral/mistral-small-latest",
+            description="A helpful agent"
+        )
+    )
+
+    server_handle = await agent.serve_async(A2AServingConfig(port=8080))
+
+    try:
+        # Keep the server running
+        await server_handle.task
+    except KeyboardInterrupt:
+        await server_handle.shutdown()
+
+asyncio.run(main())
+```
 
 ## Serving via A2A
 
@@ -23,43 +57,53 @@ For illustrative purposes, we are going to define 2 separate scripts, each defin
 
     ```python
     # google_expert.py
+    import asyncio
     from any_agent import AgentConfig, AnyAgent
     from any_agent.serving import A2AServingConfig
     from any_agent.tools import search_web
 
-    agent = AnyAgent.create(
-        "google",
-        AgentConfig(
-            name="google_expert",
-            model_id="mistral/mistral-small-latest",
-            description="An agent that can answer questions specifically and only about the Google Agents Development Kit (ADK). Reject questions about anything else.",
-            tools=[search_web]
+    async def main():
+        agent = await AnyAgent.create_async(
+            "google",
+            AgentConfig(
+                name="google_expert",
+                model_id="mistral/mistral-small-latest",
+                description="An agent that can answer questions specifically and only about the Google Agents Development Kit (ADK). Reject questions about anything else.",
+                tools=[search_web]
+            )
         )
-    )
 
-    agent.serve(A2AServingConfig(port=5001))
+        server_handle = await agent.serve_async(A2AServingConfig(port=5001))
+        await server_handle.task
+
+    asyncio.run(main())
     ```
 
 === "OpenAI Expert"
 
     ```python
     # openai_expert.py
+    import asyncio
     from any_agent import AgentConfig, AnyAgent
     from any_agent.serving import A2AServingConfig
     from any_agent.tools import search_web
 
-    agent = AnyAgent.create(
-        "openai",
-        AgentConfig(
-            name="openai_expert",
-            model_id="mistral/mistral-small-latest",
-            instructions="You can answer questions about the OpenAI Agents SDK but nothing else.",
-            description="An agent that can answer questions specifically about the OpenAI Agents SDK.",
-            tools=[search_web]
+    async def main():
+        agent = await AnyAgent.create_async(
+            "openai",
+            AgentConfig(
+                name="openai_expert",
+                model_id="mistral/mistral-small-latest",
+                instructions="You can answer questions about the OpenAI Agents SDK but nothing else.",
+                description="An agent that can answer questions specifically about the OpenAI Agents SDK.",
+                tools=[search_web]
+            )
         )
-    )
 
-    agent.serve(A2AServingConfig(port=5002))
+        server_handle = await agent.serve_async(A2AServingConfig(port=5002))
+        await server_handle.task
+
+    asyncio.run(main())
     ```
 
 We can then run each of the scripts in a separate terminal and leave them running in the background.
@@ -168,43 +212,53 @@ In a similar way to [the A2A example](#example), we are going to define two agen
 
     ```python
     # google_expert.py
+    import asyncio
     from any_agent import AgentConfig, AnyAgent
     from any_agent.serving import MCPServingConfig
     from any_agent.tools import search_web
 
-    agent = AnyAgent.create(
-        "google",
-        AgentConfig(
-            name="google_expert",
-            model_id="mistral/mistral-small-latest",
-            description="An agent that can answer questions specifically and only about the Google Agents Development Kit (ADK). Reject questions about anything else.",
-            tools=[search_web]
+    async def main():
+        agent = await AnyAgent.create_async(
+            "google",
+            AgentConfig(
+                name="google_expert",
+                model_id="mistral/mistral-small-latest",
+                description="An agent that can answer questions specifically and only about the Google Agents Development Kit (ADK). Reject questions about anything else.",
+                tools=[search_web]
+            )
         )
-    )
 
-    agent.serve(MCPServingConfig(port=5001,endpoint="/google"))
+        server_handle = await agent.serve_async(MCPServingConfig(port=5001, endpoint="/google"))
+        await server_handle.task
+
+    asyncio.run(main())
     ```
 
 === "OpenAI Expert"
 
     ```python
     # openai_expert.py
+    import asyncio
     from any_agent import AgentConfig, AnyAgent
     from any_agent.serving import MCPServingConfig
     from any_agent.tools import search_web
 
-    agent = AnyAgent.create(
-        "openai",
-        AgentConfig(
-            name="openai_expert",
-            model_id="mistral/mistral-small-latest",
-            instructions="You can provide information about the OpenAI Agents SDK but nothing else (specially, nothing about the Google SDK).",
-            description="An agent that can answer questions specifically about the OpenAI Agents SDK.",
-            tools=[search_web]
+    async def main():
+        agent = await AnyAgent.create_async(
+            "openai",
+            AgentConfig(
+                name="openai_expert",
+                model_id="mistral/mistral-small-latest",
+                instructions="You can provide information about the OpenAI Agents SDK but nothing else (specially, nothing about the Google SDK).",
+                description="An agent that can answer questions specifically about the OpenAI Agents SDK.",
+                tools=[search_web]
+            )
         )
-    )
 
-    agent.serve(MCPServingConfig(port=5002,endpoint="/openai"))
+        server_handle = await agent.serve_async(MCPServingConfig(port=5002, endpoint="/openai"))
+        await server_handle.task
+
+    asyncio.run(main())
     ```
 
 We can then run each of the scripts in a separate terminal and leave them running in the background.

--- a/src/any_agent/frameworks/any_agent.py
+++ b/src/any_agent/frameworks/any_agent.py
@@ -232,68 +232,6 @@ class AnyAgent(ABC):
         trace.final_output = final_output
         return trace
 
-    def _serve_a2a(self, serving_config: A2AServingConfig | None) -> None:
-        from any_agent.serving import A2AServingConfig, _get_a2a_app, serve_a2a
-
-        if serving_config is None:
-            serving_config = A2AServingConfig()
-
-        app = _get_a2a_app(self, serving_config=serving_config)
-
-        serve_a2a(
-            app,
-            host=serving_config.host,
-            port=serving_config.port,
-            endpoint=serving_config.endpoint,
-            log_level=serving_config.log_level,
-        )
-
-    def _serve_mcp(self, serving_config: MCPServingConfig) -> None:
-        from any_agent.serving import (
-            serve_mcp,
-        )
-
-        serve_mcp(
-            self,
-            host=serving_config.host,
-            port=serving_config.port,
-            endpoint=serving_config.endpoint,
-            log_level=serving_config.log_level,
-        )
-
-    @overload
-    def serve(self, serving_config: MCPServingConfig) -> None: ...
-
-    @overload
-    def serve(self, serving_config: A2AServingConfig | None = None) -> None: ...
-
-    def serve(
-        self, serving_config: MCPServingConfig | A2AServingConfig | None = None
-    ) -> None:
-        """Serve this agent using the protocol defined in the serving_config.
-
-        Args:
-            serving_config: Configuration for serving the agent. If None, uses default A2AServingConfig.
-                          Must be an instance of A2AServingConfig or MCPServingConfig.
-
-        Raises:
-            ImportError: If the `a2a` dependencies are not installed and an `A2AServingConfig` is used.
-
-        Example:
-            ```
-            agent = AnyAgent.create("tinyagent", AgentConfig(...))
-            config = A2AServingConfig(port=8080, endpoint="/my-agent")
-            agent.serve(config)
-            ```
-
-        """
-        from any_agent.serving import MCPServingConfig
-
-        if isinstance(serving_config, MCPServingConfig):
-            self._serve_mcp(serving_config)
-        else:
-            self._serve_a2a(serving_config)
-
     async def _serve_a2a_async(
         self, serving_config: A2AServingConfig | None
     ) -> ServerHandle:

--- a/src/any_agent/serving/__init__.py
+++ b/src/any_agent/serving/__init__.py
@@ -1,6 +1,5 @@
 from .mcp.config_mcp import MCPServingConfig
 from .mcp.server_mcp import (
-    serve_mcp,
     serve_mcp_async,
 )
 from .server_handle import ServerHandle
@@ -8,24 +7,19 @@ from .server_handle import ServerHandle
 __all__ = [
     "MCPServingConfig",
     "ServerHandle",
-    "serve_mcp",
     "serve_mcp_async",
 ]
 
 try:
     from .a2a.config_a2a import A2AServingConfig
     from .a2a.server_a2a import (
-        _get_a2a_app,
         _get_a2a_app_async,
-        serve_a2a,
         serve_a2a_async,
     )
 
     __all__ += [
         "A2AServingConfig",
-        "_get_a2a_app",
         "_get_a2a_app_async",
-        "serve_a2a",
         "serve_a2a_async",
     ]
 except ImportError:

--- a/src/any_agent/serving/a2a/envelope.py
+++ b/src/any_agent/serving/a2a/envelope.py
@@ -64,34 +64,6 @@ def _create_a2a_envelope(body_type: type[BaseModel]) -> type[A2AEnvelope[Any]]:
     return EnvelopeInstance
 
 
-def prepare_agent_for_a2a(agent: AnyAgent) -> AnyAgent:
-    """Return an agent whose ``config.output_type`` is A2A-ready.
-
-    If *agent* is already envelope-compatible we hand it back untouched.
-    Otherwise we clone its config, wrap the output type, and spin up a
-    *new* agent instance via `AnyAgent.create` so that framework-specific
-    initialisation sees the correct schema right from the start.
-
-    This function preserves MCP servers from the original agent to avoid
-    connection timeouts.
-    """
-    if _is_a2a_envelope(agent.config.output_type):
-        return agent
-
-    body_type = agent.config.output_type or _DefaultBody
-    new_output_type = _create_a2a_envelope(body_type)
-
-    original_callbacks = agent.config.callbacks
-    agent.config.callbacks = []
-    new_config = agent.config.model_copy(deep=True)
-    new_config.output_type = new_output_type
-    new_config.callbacks = original_callbacks
-    agent.config.callbacks = original_callbacks
-
-    # Create the new agent with the wrapped config, preserving MCP servers and tools
-    return agent._recreate_with_config(new_config)
-
-
 async def prepare_agent_for_a2a_async(agent: AnyAgent) -> AnyAgent:
     """Async counterpart of :pyfunc:`prepare_agent_for_a2a`.
 

--- a/src/any_agent/serving/a2a/server_a2a.py
+++ b/src/any_agent/serving/a2a/server_a2a.py
@@ -12,40 +12,14 @@ from starlette.routing import Mount
 
 from any_agent.serving.a2a.context_manager import ContextManager
 from any_agent.serving.server_handle import ServerHandle
-from any_agent.utils import run_async_in_sync
 
 from .agent_card import _get_agent_card
 from .agent_executor import AnyAgentExecutor
-from .envelope import prepare_agent_for_a2a, prepare_agent_for_a2a_async
+from .envelope import prepare_agent_for_a2a_async
 
 if TYPE_CHECKING:
-    from multiprocessing import Queue
-
     from any_agent import AnyAgent
     from any_agent.serving import A2AServingConfig
-
-
-def _get_a2a_app(
-    agent: AnyAgent, serving_config: A2AServingConfig
-) -> A2AStarletteApplication:
-    agent = prepare_agent_for_a2a(agent)
-
-    agent_card = _get_agent_card(agent, serving_config)
-    task_manager = ContextManager(serving_config)
-    push_notification_config_store = serving_config.push_notifier_store_type()
-    push_notification_sender = serving_config.push_notifier_sender_type(
-        httpx_client=httpx.AsyncClient(),
-        config_store=push_notification_config_store,
-    )
-
-    request_handler = DefaultRequestHandler(
-        agent_executor=AnyAgentExecutor(agent, task_manager),
-        task_store=serving_config.task_store_type(),
-        push_config_store=push_notification_config_store,
-        push_sender=push_notification_sender,
-    )
-
-    return A2AStarletteApplication(agent_card=agent_card, http_handler=request_handler)
 
 
 async def _get_a2a_app_async(
@@ -102,25 +76,3 @@ async def serve_a2a_async(
         server_port = uv_server.servers[0].sockets[0].getsockname()[1]
         server.agent_card.url = f"http://{host}:{server_port}/{endpoint.lstrip('/')}"
     return ServerHandle(task=task, server=uv_server)
-
-
-def serve_a2a(
-    server: A2AStarletteApplication,
-    host: str,
-    port: int,
-    endpoint: str,
-    log_level: str = "warning",
-    server_queue: Queue[int] | None = None,
-) -> None:
-    """Serve the A2A server."""
-
-    # Note that the task should be kept somewhere
-    # because the loop only keeps weak refs to tasks
-    # https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task
-    async def run() -> None:
-        server_handle = await serve_a2a_async(server, host, port, endpoint, log_level)
-        if server_queue:
-            server_queue.put(server_handle.port)
-        await server_handle.task
-
-    return run_async_in_sync(run())

--- a/src/any_agent/serving/mcp/server_mcp.py
+++ b/src/any_agent/serving/mcp/server_mcp.py
@@ -13,7 +13,6 @@ from starlette.responses import Response
 from starlette.routing import Mount, Route
 
 from any_agent.serving.server_handle import ServerHandle
-from any_agent.utils import run_async_in_sync
 
 if TYPE_CHECKING:
     from starlette.requests import Request
@@ -101,22 +100,3 @@ async def serve_mcp_async(
     while not uv_server.started:  # noqa: ASYNC110
         await asyncio.sleep(0.1)
     return ServerHandle(task=task, server=uv_server)
-
-
-def serve_mcp(
-    agent: AnyAgent,
-    host: str,
-    port: int,
-    endpoint: str,
-    log_level: str = "warning",
-) -> None:
-    """Serve the MCP server."""
-
-    # Note that the task should be kept somewhere
-    # because the loop only keeps weak refs to tasks
-    # https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task
-    async def run() -> None:
-        server_handle = await serve_mcp_async(agent, host, port, endpoint, log_level)
-        await server_handle.task
-
-    return run_async_in_sync(run())

--- a/src/any_agent/tools/a2a.py
+++ b/src/any_agent/tools/a2a.py
@@ -53,7 +53,9 @@ async def a2a_tool_async(
     if "timeout" not in http_kwargs:
         http_kwargs["timeout"] = 30.0
 
-    async with httpx.AsyncClient(follow_redirects=True) as resolver_client:
+    async with httpx.AsyncClient(
+        follow_redirects=True, **http_kwargs
+    ) as resolver_client:
         a2a_agent_card: AgentCard = await (
             A2ACardResolver(httpx_client=resolver_client, base_url=url)
         ).get_agent_card()

--- a/tests/integration/a2a/test_a2a_serve.py
+++ b/tests/integration/a2a/test_a2a_serve.py
@@ -1,9 +1,6 @@
-import multiprocessing
 from uuid import uuid4
 
-import httpx
 import pytest
-from a2a.client import A2AClient
 
 # Import your agent and config
 from any_agent import AgentConfig, AgentFramework, AnyAgent
@@ -16,45 +13,6 @@ from any_agent.testing.helpers import (
 )
 
 from .conftest import A2ATestHelpers, a2a_client_from_agent
-
-
-def serve_agent(port: int) -> None:
-    agent = AnyAgent.create(
-        "tinyagent",
-        AgentConfig(
-            model_id=DEFAULT_SMALL_MODEL_ID,
-            instructions="Directly answer the question without asking the user for input.",
-            description="I'm an agent to help.",
-            model_args=get_default_agent_model_args(AgentFramework.TINYAGENT),
-        ),
-    )
-    agent.serve(serving_config=A2AServingConfig(port=port))
-
-
-@pytest.mark.asyncio
-async def test_serve_sync(test_port: int, a2a_test_helpers: A2ATestHelpers) -> None:
-    # Start the agent in a subprocess
-    proc = multiprocessing.Process(target=serve_agent, args=(test_port,), daemon=True)
-    proc.start()
-    server_url = f"http://localhost:{test_port}"
-    await wait_for_server_async(server_url)
-
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as httpx_client:
-            client = await A2AClient.get_client_from_agent_card_url(
-                httpx_client, server_url
-            )
-
-            request = a2a_test_helpers.create_send_message_request(
-                text="What is an agent?"
-            )
-            response = await client.send_message(
-                request, http_kwargs=DEFAULT_HTTP_KWARGS
-            )
-            assert response is not None
-    finally:
-        proc.kill()
-        proc.join()
 
 
 @pytest.mark.asyncio
@@ -73,8 +31,9 @@ async def test_serve_async(test_port: int, a2a_test_helpers: A2ATestHelpers) -> 
     # Use the context manager for proper cleanup
     async with a2a_client_from_agent(agent, A2AServingConfig(port=test_port)) as (
         client,
-        _,
+        server_url,
     ):
+        await wait_for_server_async(server_url)
         request = a2a_test_helpers.create_send_message_request(
             text="What is an agent?",
             message_id=uuid4().hex,

--- a/tests/unit/serving/test_envelope_creation.py
+++ b/tests/unit/serving/test_envelope_creation.py
@@ -13,7 +13,7 @@ from any_agent.serving.a2a.envelope import (
     A2AEnvelope,
     _DefaultBody,
     _is_a2a_envelope,
-    prepare_agent_for_a2a,
+    prepare_agent_for_a2a_async,
 )
 
 
@@ -46,7 +46,8 @@ class MockAgent(AnyAgent):
         return cls(config)
 
 
-def test_envelope_created_without_output_type() -> None:
+@pytest.mark.asyncio
+async def test_envelope_created_without_output_type() -> None:
     """Test that the envelope is correctly created when the agent is configured without an output_type."""
     # Create agent config without output_type
     config = AgentConfig(model_id="test-model", description="test agent")
@@ -56,7 +57,7 @@ def test_envelope_created_without_output_type() -> None:
     agent = MockAgent(config)
 
     # Prepare agent for A2A
-    prepared_agent = prepare_agent_for_a2a(agent)
+    prepared_agent = await prepare_agent_for_a2a_async(agent)
 
     # Verify the envelope was created with default body
     assert prepared_agent.config.output_type is not None
@@ -73,7 +74,8 @@ def test_envelope_created_without_output_type() -> None:
     assert envelope_instance.data.result == "test result"
 
 
-def test_envelope_created_with_output_type() -> None:
+@pytest.mark.asyncio
+async def test_envelope_created_with_output_type() -> None:
     """Test that the envelope is correctly created when an agent is configured with an output_type."""
     # Create agent config with custom output_type
     config = AgentConfig(
@@ -84,7 +86,7 @@ def test_envelope_created_with_output_type() -> None:
     agent = MockAgent(config)
 
     # Prepare agent for A2A
-    prepared_agent = prepare_agent_for_a2a(agent)
+    prepared_agent = await prepare_agent_for_a2a_async(agent)
 
     # Verify the envelope was created with custom output type
     assert prepared_agent.config.output_type is not None


### PR DESCRIPTION
Putting this PR here to see how you all feel about it.

The sync server implementation is basically a wrapper around our async functions except that it adds a bunch of complexity and testing needs. Additionally, if someone is serving an agent, arguably they should not be using the sync version anyways for performance reasons.

With this in mind, I propose removing our `anyagent.serve` function, and adding a short section to our documentation explaining how easy it is to wrap the server in a sync function and run it with asyncio if they choose to do so.