### PR TITLE
fix: consistent prompts and simplification of structured output prompt

### DIFF
--- a/src/any_agent/frameworks/google.py
+++ b/src/any_agent/frameworks/google.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 from pydantic import BaseModel
 
 from any_agent.config import AgentConfig, AgentFramework
-from any_agent.tools.final_output import FinalOutputTool
+from any_agent.tools.final_output import prepare_final_output_config_function
 
 from .any_agent import AnyAgent
 
@@ -61,13 +61,10 @@ class GoogleAgent(AnyAgent):
 
         instructions = self.config.instructions or ""
         if self.config.output_type:
-            instructions += (
-                "You must call the final_output tool when finished."
-                "The 'answer' argument passed to the final_output tool must be a JSON string that matches the following schema:\n"
-                f"{self.config.output_type.model_json_schema()}"
+            instructions, final_output_function = prepare_final_output_config_function(
+                self.config.output_type, instructions
             )
-            output_fn = FinalOutputTool(self.config.output_type)
-            tools.append(output_fn)
+            tools.append(final_output_function)
 
         self._agent = agent_type(
             name=self.config.name,

--- a/src/any_agent/frameworks/llama_index.py
+++ b/src/any_agent/frameworks/llama_index.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, ValidationError
 
 from any_agent import AgentConfig, AgentFramework
 from any_agent.logging import logger
-from any_agent.tools.final_output import FinalOutputTool
+from any_agent.tools.final_output import prepare_final_output_config_function
 
 from .any_agent import AnyAgent
 
@@ -67,13 +67,10 @@ class LlamaIndexAgent(AnyAgent):
         instructions = self.config.instructions
         tools_to_use = list(self.config.tools)
         if self.config.output_type:
-            instructions = instructions or ""
-            instructions += f"""You must return a {self.config.output_type.__name__} JSON string.
-            This object must match the following schema:
-            {self.config.output_type.model_json_schema()}
-            You can use the 'final_output' tool to help verify your output
-            """
-            tools_to_use.append(FinalOutputTool(self.config.output_type))
+            instructions, final_output_function = prepare_final_output_config_function(
+                self.config.output_type, instructions
+            )
+            tools_to_use.append(final_output_function)
         imported_tools, _ = await self._load_tools(tools_to_use)
         agent_type = self.config.agent_type or DEFAULT_AGENT_TYPE
         # if agent type is FunctionAgent but there are no tools, throw an error

--- a/src/any_agent/frameworks/smolagents.py
+++ b/src/any_agent/frameworks/smolagents.py
@@ -1,9 +1,11 @@
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
 
 from any_agent.config import AgentConfig, AgentFramework
 from any_agent.frameworks.any_agent import AnyAgent
+from any_agent.tools.final_output import prepare_final_output_config_function
 
 try:
     from smolagents import FinalAnswerTool, LiteLLMModel, ToolCallingAgent
@@ -71,28 +73,31 @@ class SmolagentsAgent(AnyAgent):
             self._agent.prompt_templates["system_prompt"] = self.config.instructions
 
         if self.config.output_type:
-            output_type = self.config.output_type
+            instructions, final_output_function = prepare_final_output_config_function(
+                self.config.output_type, self.config.instructions
+            )
 
-            class CustomFinalAnswerTool(FinalAnswerTool):  # type: ignore[no-untyped-call]
-                inputs = {  # noqa: RUF012
-                    "answer": {
-                        "type": "string",
-                        "description": f"The final answer to the problem. The input must be a string that conforms to the{output_type.__name__} object.",
-                    }
-                }
+            # Create a custom tool for smolagents that wraps our final output function
+            class FinalAnswerToolWrapper(FinalAnswerTool):  # type: ignore[no-untyped-call]
+                def __init__(
+                    self, final_output_func: Callable[[str], dict[str, str | bool]]
+                ):
+                    super().__init__()  # type: ignore[no-untyped-call]
+                    self.final_output_func = final_output_func
 
                 def forward(self, answer: str) -> Any:
-                    output_type.model_validate_json(answer)
-                    return answer
+                    result = self.final_output_func(answer)
+                    if result.get("success"):
+                        return result["result"]
+                    raise ValueError(result["result"])
 
-            self._agent.tools["final_answer"] = CustomFinalAnswerTool()  # type: ignore[no-untyped-call]
+            self._agent.tools["final_answer"] = FinalAnswerToolWrapper(
+                final_output_function
+            )
 
-            self._agent.prompt_templates[
-                "system_prompt"
-            ] += f"""\n\nYour final answer must be a {self.config.output_type.__name__} object.
-            This object must match the following schema:
-            {self.config.output_type.model_json_schema()}
-            """
+            # Update the system prompt with the modified instructions
+            if instructions:
+                self._agent.prompt_templates["system_prompt"] = instructions
         assert self._agent
 
     async def _run_async(self, prompt: str, **kwargs: Any) -> str | BaseModel:

--- a/src/any_agent/frameworks/smolagents.py
+++ b/src/any_agent/frameworks/smolagents.py
@@ -84,6 +84,20 @@ class SmolagentsAgent(AnyAgent):
                 ):
                     super().__init__()  # type: ignore[no-untyped-call]
                     self.final_output_func = final_output_func
+                    # Copying the __doc__ relies upon the final_output_func having a single str parameter called "answer"
+                    if (
+                        not self.final_output_func.__code__.co_varnames[0] == "answer"
+                        or not self.final_output_func.__doc__
+                    ):
+                        msg = "The final_output_func must have a single parameter of type str"
+                        raise ValueError(msg)
+
+                    self.inputs = {
+                        "answer": {
+                            "type": "string",
+                            "description": self.final_output_func.__doc__,
+                        }
+                    }
 
                 def forward(self, answer: str) -> Any:
                     result = self.final_output_func(answer)

--- a/src/any_agent/tools/__init__.py
+++ b/src/any_agent/tools/__init__.py
@@ -1,5 +1,5 @@
 from .a2a import a2a_tool, a2a_tool_async
-from .final_output import FinalOutputTool
+from .final_output import prepare_final_output_config_function
 from .mcp import (
     MCPServer,
     _get_mcp_server,
@@ -15,7 +15,6 @@ from .user_interaction import (
 from .web_browsing import search_tavily, search_web, visit_webpage
 
 __all__ = [
-    "FinalOutputTool",
     "MCPServer",
     "_MCPConnection",
     "_MCPServerBase",
@@ -23,6 +22,7 @@ __all__ = [
     "a2a_tool",
     "a2a_tool_async",
     "ask_user_verification",
+    "prepare_final_output_config_function",
     "search_tavily",
     "search_web",
     "send_console_message",

--- a/src/any_agent/tools/final_output.py
+++ b/src/any_agent/tools/final_output.py
@@ -1,32 +1,31 @@
 import json
+from collections.abc import Callable
 
 from pydantic import BaseModel, ValidationError
 
 
-class FinalOutputTool:
-    """A serializable final output tool that avoids closure issues."""
+def prepare_final_output_config_function(
+    output_type: type[BaseModel], instructions: str | None = None
+) -> tuple[str, Callable[[str], dict[str, str | bool]]]:
+    """Prepare instructions and tools for structured output, returning the function directly.
 
-    def __init__(self, output_type: type[BaseModel]):
-        """Create the function that will be used as a tool."""
-        self.output_type = output_type
-        # Set docstring for the callable object
-        self.__doc__ = f"""You must call this tool in order to return the final answer.
+    Args:
+        output_type: The Pydantic model type for structured output
+        instructions: Original instructions to modify
 
-        Args:
-            answer: The final output that can be loaded as a Pydantic model. This must be a JSON compatible string that matches the following schema:
-                {output_type.model_json_schema()}
+    Returns:
+        Tuple of (modified_instructions, final_output_function)
 
-        Returns:
-            A dictionary with the following keys:
-                - success: True if the output is valid, False otherwise.
-                - result: The final output if success is True, otherwise an error message.
+    """
+    tool_name = "final_output"
+    modified_instructions = instructions or ""
+    modified_instructions += (
+        f"You must call the {tool_name} tool when finished."
+        f"The 'answer' argument passed to the {tool_name} tool must be a JSON string that matches the following schema:\n"
+        f"{output_type.model_json_schema()}"
+    )
 
-        """
-        # Set function name for tool frameworks that expect it
-        self.__name__ = "final_output"
-
-    def __call__(self, answer: str) -> dict:  # type: ignore[type-arg]
-        """Validate the final output."""
+    def final_output_tool(answer: str) -> dict[str, str | bool]:
         # First check if it's valid JSON
         try:
             json.loads(answer)
@@ -37,11 +36,28 @@ class FinalOutputTool:
             }
         # Then validate against the Pydantic model
         try:
-            self.output_type.model_validate_json(answer)
+            output_type.model_validate_json(answer)
         except ValidationError as e:
             return {
                 "success": False,
-                "result": f"Please fix this validation error: {e}. The format must conform to {self.output_type.model_json_schema()}",
+                "result": f"Please fix this validation error: {e}. The format must conform to {output_type.model_json_schema()}",
             }
         else:
             return {"success": True, "result": answer}
+
+    # Set the function name and docstring
+    final_output_tool.__name__ = tool_name
+    final_output_tool.__doc__ = f"""This tool is used to validate the final output. It must be called when the final answer is ready in order to ensure that the output is valid.
+
+    Args:
+        answer: The final output that can be loaded as a Pydantic model. This must be a JSON compatible string that matches the following schema:
+            {output_type.model_json_schema()}
+
+    Returns:
+        A dictionary with the following keys:
+            - success: True if the output is valid, False otherwise.
+            - result: The final output if success is True, otherwise an error message.
+
+    """
+
+    return modified_instructions, final_output_tool


### PR DESCRIPTION
* turn class into function because there's no need for the class
* Now all the frameworks that add the final answer as a tool use the same function and prompt.

I have some work left on the frameworks that weren't using FinalOutputTool, which I'll tackle next.

