### PR TITLE
fix(hooks): Add `any-agent` to `BASE_URL`.

### DIFF
--- a/scripts/hooks.py
+++ b/scripts/hooks.py
@@ -11,7 +11,7 @@ from pathlib import Path
 # Constants
 MARKDOWN_EXTENSION = ".md"
 TEXT_EXTENSION = ".txt"
-BASE_URL = "https://mozilla-ai.github.io/"
+BASE_URL = "https://mozilla-ai.github.io/any-agent/"
 ENCODING = "utf-8"
 EXCLUDED_DIRS = {".", "__pycache__"}
 TOC_PATTERN = r"^\s*\[\[TOC\]\]\s*$"


### PR DESCRIPTION
Tested locally with `mkdocs build` and manually checking the generated `site`:

<img width="815" height="253" alt="image" src="https://github.com/user-attachments/assets/c9228428-d619-4bb3-b6fa-c70f6c0f009d" />

