### PR TITLE
Add a unit test to check typing imports

### DIFF
--- a/tests/unit/serving/test_a2a_imports.py
+++ b/tests/unit/serving/test_a2a_imports.py
@@ -1,0 +1,14 @@
+import pytest
+
+# Skip entire module if a2a dependencies are not available
+pytest.importorskip("any_agent.serving.a2a.config_a2a")
+
+
+@pytest.mark.asyncio
+async def test_a2a_imports() -> None:
+    """Test that A2A serving can be imported."""
+    from any_agent.serving import (
+        serve_a2a_async
+    )
+
+

--- a/tests/unit/serving/test_agent_card.py
+++ b/tests/unit/serving/test_agent_card.py
@@ -10,8 +10,7 @@ from any_agent.tools.wrappers import WRAPPERS
 
 # Skip entire module if a2a dependencies are not available
 pytest.importorskip("a2a.types")
-pytest.importorskip("any_agent.serving.agent_card")
-pytest.importorskip("typing.override")
+pytest.importorskip("any_agent.serving.a2a.agent_card")
 
 
 from a2a.types import AgentSkill

--- a/tests/unit/serving/test_envelope_creation.py
+++ b/tests/unit/serving/test_envelope_creation.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel
 
 # Skip entire module if a2a dependencies are not available
 pytest.importorskip("a2a.types")
-pytest.importorskip("any_agent.serving.envelope")
+pytest.importorskip("any_agent.serving.a2a.envelope")
 
 from a2a.types import TaskState
 


### PR DESCRIPTION
Adds a unit test to check that the `typing` constructs are imported appropriately. It also fixes some unit tests that were masked due to broken imports.

Closes #569 