### PR TITLE
Exposed max_length in visit_webpage interface

### DIFF
--- a/src/any_agent/tools/web_browsing.py
+++ b/src/any_agent/tools/web_browsing.py
@@ -41,12 +41,14 @@ def search_web(query: str) -> str:
     )
 
 
-def visit_webpage(url: str, timeout: int = 30) -> str:
+def visit_webpage(url: str, timeout: int = 30, max_length: int = 10000) -> str:
     """Visits a webpage at the given url and reads its content as a markdown string. Use this to browse webpages.
 
     Args:
         url: The url of the webpage to visit.
         timeout: The timeout in seconds for the request.
+        max_length: The maximum number of characters of text that can be returned (default=10000).
+                    If max_length==-1, text is not truncated and the full webpage is returned.
 
     """
     try:
@@ -57,7 +59,9 @@ def visit_webpage(url: str, timeout: int = 30) -> str:
 
         markdown_content = re.sub(r"\n{2,}", "\n", markdown_content)
 
-        return _truncate_content(markdown_content, 10000)
+        if max_length == -1:
+            return str(markdown_content)
+        return _truncate_content(markdown_content, max_length)
     except RequestException as e:
         return f"Error fetching the webpage: {e!s}"
     except Exception as e:


### PR DESCRIPTION
Updated `visit_webpage` interface to expose the `max_length` parameter. Now:

- the tool can be called as previously without specifying it, and it will use the same value (10000) by default
- if called with a different max_length, the specified value will be used
- if called with max_length == -1, no truncation will occur.

This information is exposed in the docstring so one can either use the default or explicitly ask to download full webpages / use a specific value for max_length.

Ran unit/integration tests locally.

Tested with the following code:

```
from any_agent import AgentConfig, AnyAgent
from any_agent.tools import search_tavily, visit_webpage

agent = AnyAgent.create(
    "smolagents",
    AgentConfig(
        model_id="ollama/qwen3:8b",
        instructions="""You must use the available tools to find an answer.""",
        tools=[visit_webpage],
    ),
)

agent_trace = agent.run(
    "When was Denny Vrandecic born?"
)
```

Results:

- without `visit_webpage`: the model makes up the birth date
- with `visit_webpage`: the default length (10k) is used, the information is not there, and the model makes up the birth date
- with the following prompts:
  -  "When was Denny Vrandecic born? IMPORTANT: always download full webpages." (LLM sets max_length to -1)
  -  "When was Denny Vrandecic born? Set visit_webpage's max_length to 20000." (LLM sets max_length to 20000)
  -  "When was Denny Vrandecic born? If you cannot get this information from the downloaded page, use a larger max_length value" (LLM sets max_length to 50000 immediately)
... the model downloads all the required content and answers with the proper date:

`Denny Vrandečić was born on 27 February 1978 in Stuttgart, Germany.`

Closes #644 