### PR TITLE
Enable OTel instrumentation and propagation

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -123,3 +123,11 @@ tp = get_tracer_provider()
 http_exporter = OTLPSpanExporter(endpoint="http://localhost:4318/v1/traces")
 tp.add_span_processor(SimpleSpanProcessor(http_exporter))
 ```
+
+## Distributed tracing
+
+### A2A
+
+When serving an agent via A2A, the server can be instrumented so that any W3C trace and parent span IDs received are included in the OpenTelemetry traces used by the served agent. It is only enabled if the `instrument_server` parameter is set to `True` in the [`A2AServingConfig`][any_agent.serving.A2AServingConfig] passed when serving the agent.
+
+Likewise, an agent using an A2A served agent with the [`a2a_tool`][any_agent.tools.a2a_tool] or [`a2a_tool_async`][any_agent.tools.a2a_tool_async] functions can set the `instrument_client` parameter to `True` to inject OpenTelemetry trace and parent span IDs into the A2A HTTP calls.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
   "mcp>=1.5.0",
   "opentelemetry-exporter-otlp",
   "opentelemetry-sdk",
+  "opentelemetry-instrumentation-httpx",
+  "opentelemetry-instrumentation-starlette",
   "pydantic",
   "requests",
   "rich",

--- a/src/any_agent/callbacks/span_generation/smolagents.py
+++ b/src/any_agent/callbacks/span_generation/smolagents.py
@@ -19,7 +19,7 @@ class _SmolagentsSpanGeneration(_SpanGeneration):
         messages: list[ChatMessage] = args[0]
         input_messages = [
             {
-                "role": message.role.value,  # type: ignore[attr-defined]
+                "role": message.role.value,
                 "content": message.content[0]["text"],  # type: ignore[index]
             }
             for message in messages

--- a/src/any_agent/frameworks/any_agent.py
+++ b/src/any_agent/frameworks/any_agent.py
@@ -252,6 +252,7 @@ class AnyAgent(ABC):
             port=serving_config.port,
             endpoint=serving_config.endpoint,
             log_level=serving_config.log_level,
+            instrument_server=serving_config.instrument_server,
         )
 
     async def _serve_mcp_async(self, serving_config: MCPServingConfig) -> ServerHandle:

--- a/src/any_agent/serving/a2a/config_a2a.py
+++ b/src/any_agent/serving/a2a/config_a2a.py
@@ -120,3 +120,8 @@ class A2AServingConfig(BaseModel):
 
     If not provided, a default in-memory task store will be used.
     """
+
+    instrument_server: bool = False
+    """Whether to instrument the server to receive and use OpenTelemetry tracing.
+
+    If not provided, OpenTelemetry instrumentation is disabled."""

--- a/tests/integration/a2a/conftest.py
+++ b/tests/integration/a2a/conftest.py
@@ -75,6 +75,7 @@ class A2AServedAgent:
         self,
         agent: AnyAgent,
         serving_config: A2AServingConfig | None = None,
+        instrument: bool = True,
     ):
         self.agent = agent
         self.serving_config = serving_config or A2AServingConfig(port=0)

--- a/tests/unit/tools/test_unit_wrappers.py
+++ b/tests/unit/tools/test_unit_wrappers.py
@@ -109,7 +109,7 @@ def test_wrap_tool_smolagents_builtin_tools() -> None:
 
     wrapper = MagicMock()
     with patch("smolagents.tool", wrapper):
-        _wrap_tool_smolagents(DuckDuckGoSearchTool())  # type: ignore[no-untyped-call]
+        _wrap_tool_smolagents(DuckDuckGoSearchTool())
         wrapper.assert_not_called()
 
 


### PR DESCRIPTION
This PR adds optional flags to enable OTel distributed tracing in the httpx/starlette packages.