### PR TITLE
Removed deletion of final_answer when output_type is not defined

### DIFF
--- a/src/any_agent/frameworks/smolagents.py
+++ b/src/any_agent/frameworks/smolagents.py
@@ -58,9 +58,6 @@ class SmolagentsAgent(AnyAgent):
         if not self._agent:
             return
 
-        if "final_answer" in self._agent.tools:
-            del self._agent.tools["final_answer"]
-
         if self.config.instructions:
             self._agent.prompt_templates["system_prompt"] = self.config.instructions
 


### PR DESCRIPTION
Re: https://github.com/mozilla-ai/any-agent/issues/662 - I do not envision a case where we would want to remove `final_answer` from smolagent tools unless we provide an output type, so I took the liberty of suggesting this patch.

I tested this locally and worked as expected (i.e. now the agent terminates correctly) but I am not 100% sure it will not have other consequences I might have missed (let's see how the tests do in the meantime... :-) ).

Closes https://github.com/mozilla-ai/any-agent/issues/662