### PR TITLE
chore: Omit `tests/` folder in codecov.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,8 @@ timeout = 120
 [tool.coverage.run]
 branch = true
 omit = [
-  "src/any_agent/vendor/*"
+  "src/any_agent/vendor/*",
+  "tests/"
 ]
 
 [dependency-groups]


### PR DESCRIPTION
https://about.codecov.io/blog/should-i-include-test-files-in-code-coverage-calculations/