### PR TITLE
Check precommit cache

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,12 +24,5 @@ jobs:
       - name: Install pre-commit
         run: uv sync --group lint
 
-      - uses: actions/cache@v4
-        with:
-          path: ~/.cache/pre-commit
-          key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pre-commit-
-
       - name: pre-commit
         run: uv run pre-commit run --all-files --verbose


### PR DESCRIPTION
The precommit cache may also keep obsolete mypy data. This will be rolled back if it does not affect type checks.