### PR TITLE
fix(a2a): Make instructions of `_send_query` more clear.

### DIFF
--- a/src/any_agent/tools/a2a.py
+++ b/src/any_agent/tools/a2a.py
@@ -156,10 +156,11 @@ async def a2a_tool_async(
 
         Args:
             query (str): The query to send to the agent.
-            task_id (str, optional): Task ID for continuing an incomplete task. Use the same
-                task_id from a previous response with TaskState.input_required to resume the task. If you want to start a new task, you should not provide a task id.
-            context_id (str, optional): Context ID for conversation continuity. Provides the
-                agent with conversation history. Omit to start a fresh conversation. If you want to start a new conversation, you should not provide a context id.
+            task_id (str, optional): Task ID for continuing an incomplete task.
+                If you want to start a new task, you should not provide a task_id (pass `task_id=None`).
+                If you want to resume a task, use the same task_id from a previous response with TaskState.input_required.
+            context_id (str, optional): Context ID for conversation continuity.
+                If you want to start a new conversation, you should not provide a context_id (pass `context_id=None`).
 
         Returns:
             dict: Response from the A2A agent containing:


### PR DESCRIPTION
The cause of the failures was the agent deciding to pass `"'0"` as task_id instead of `None`.

<img width="714" height="434" alt="Screenshot 2025-08-04 132218" src="https://github.com/user-attachments/assets/1234cd86-30f1-40f7-b76b-1d28e7b65e94" />

Integration tests:

https://github.com/mozilla-ai/any-agent/actions/runs/16721786710/job/47327664062