### PR TITLE
chore(deps): make tool dependencies optional.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,7 @@ license = {text = "Apache-2.0"}
 requires-python = ">=3.11"
 dynamic = ["version"]
 dependencies = [
-  "duckduckgo_search",
   "litellm>=1.74.0",
-  "markdownify",
   "mcp>=1.5.0",
   "opentelemetry-sdk",
   "pydantic",

--- a/src/any_agent/tools/web_browsing.py
+++ b/src/any_agent/tools/web_browsing.py
@@ -2,16 +2,7 @@ import os
 import re
 
 import requests
-from duckduckgo_search import DDGS
-from markdownify import markdownify
 from requests.exceptions import RequestException
-
-try:
-    from tavily.tavily import TavilyClient
-
-    tavily_available = True
-except ImportError:
-    tavily_available = False
 
 
 def _truncate_content(content: str, max_length: int) -> str:
@@ -34,6 +25,12 @@ def search_web(query: str) -> str:
         The top search results.
 
     """
+    try:
+        from duckduckgo_search import DDGS
+    except ImportError as e:
+        msg = "You need to `pip install 'duckduckgo_search'` to use this tool"
+        raise ImportError(msg) from e
+
     ddgs = DDGS()
     results = ddgs.text(query, max_results=10)
     return "\n".join(
@@ -51,6 +48,12 @@ def visit_webpage(url: str, timeout: int = 30, max_length: int = 10000) -> str:
                     If max_length==-1, text is not truncated and the full webpage is returned.
 
     """
+    try:
+        from markdownify import markdownify
+    except ImportError as e:
+        msg = "You need to `pip install 'markdownify'` to use this tool"
+        raise ImportError(msg) from e
+
     try:
         response = requests.get(url, timeout=timeout)
         response.raise_for_status()
@@ -81,9 +84,12 @@ def search_tavily(query: str, include_images: bool = False) -> str:
         The top search results as a formatted string.
 
     """
-    if not tavily_available:
+    try:
+        from tavily.tavily import TavilyClient
+    except ImportError as e:
         msg = "You need to `pip install 'tavily-python'` to use this tool"
-        raise ImportError(msg)
+        raise ImportError(msg) from e
+
     api_key = os.getenv("TAVILY_API_KEY")
     if not api_key:
         return "TAVILY_API_KEY environment variable not set."


### PR DESCRIPTION
This is technically not a breaking change that requires a major version bump, according to my opinion and the opinion of gemini-2.5-pro 😅 :

```
1. The Semantic Versioning Definition of "Breaking"

SemVer 2.0.0 defines a MAJOR version bump (e.g., 1.5.2 -> 2.0.0) as the result of an incompatible API change.

Let's analyze what "API" means in this context:

    The Code API: This refers to your public-facing functions, classes, methods, and their signatures (arguments, return types). In your case, the optional functions still exist. Their signatures have not changed. A user's code that calls my_optional_function() is still syntactically correct.

    The Installation/Environment Contract: This is the user's expectation that after pip install my-package, certain features will be available. You are changing this contract.

Because the code API itself is not broken, a MAJOR version bump is not strictly required. You haven't removed my_optional_function or changed how it's called.
```