### PR TITLE
Make sure that every tool is wrapped only once

### DIFF
--- a/src/any_agent/callbacks/wrappers/openai.py
+++ b/src/any_agent/callbacks/wrappers/openai.py
@@ -84,8 +84,13 @@ class _OpenAIAgentsWrapper:
                 original_invoke = original_tool.on_invoke_tool
                 self._original_invokes[original_tool.name] = original_invoke
 
-                wrapped_tool = WrappedTool(original_tool, original_invoke)
-                original_tool.on_invoke_tool = wrapped_tool.on_invoke_tool
+                # check if the original tool invocation comes from a WrappedTool, if not wrap it
+                if (
+                    not hasattr(original_tool.on_invoke_tool, "__qualname__")
+                    or "WrappedTool" not in original_tool.on_invoke_tool.__qualname__
+                ):
+                    wrapped_tool = WrappedTool(original_tool, original_invoke)
+                    original_tool.on_invoke_tool = wrapped_tool.on_invoke_tool
 
             return all_tools
 


### PR DESCRIPTION
This PR tackles an [issue](https://github.com/mozilla-ai/any-agent/issues/729) where tool calls / outputs / spans in traces appear repeatedly.

I double checked the traces and the code and verified that the code was called only once, but the accompanying callbacks were called multiple times (one more each turn). I found that the reason is that tools are not wrapped just once, but this happens repeatedly causing a babushka 🪆 of wrappers.

As this does not happen with wrappers for other frameworks, I think it might be due to how openai manages its tools and particularly his `get_all_tools` command (the one which is patched with `wrapped_get_all_tools`. 

This PR brings a patch that only applies a wrapper to a tool that has not been wrapped already, tackling the babushka issue. I tested it with both https://github.com/mozilla-ai/agent-factory/pull/201 and https://github.com/mozilla-ai/agent-factory/pull/237 where this problem occurred.

Closes #729 