### PR TITLE
chore(deps): Pin "openai<1.100".

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.11"
 dynamic = ["version"]
 dependencies = [
   "any-llm-sdk>=0.13.0,<1",
+  "openai<1.100",
   "litellm>=1.74.0",
   "mcp>=1.5.0",
   "opentelemetry-sdk",


### PR DESCRIPTION
litellm is still breaking due to https://github.com/openai/openai-python/issues/2564 