### PR TITLE
Use absolute URL for logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <picture>
-    <img src="docs/images/any-agent-logo-mark.png" width="20%" alt="Project logo"/>
+    <img src="https://raw.githubusercontent.com/mozilla-ai/any-agent/refs/heads/main/docs/images/any-agent-logo-mark.png" width="20%" alt="Project logo"/>
   </picture>
 </p>
 


### PR DESCRIPTION
Update the image logo in the README to use an absolute URL pointing to the raw GitHub content. This change ensures that the image is displayed correctly on external sites that render the README, such as PyPI.