### PR TITLE
fix(test_agent): Disable HF/TGI model in integration tests

### DIFF
--- a/tests/integration/frameworks/test_agent.py
+++ b/tests/integration/frameworks/test_agent.py
@@ -111,7 +111,9 @@ class Steps(BaseModel):
     [
         "anthropic/claude-3-5-haiku-latest",
         "google/gemini-2.5-flash",
-        "huggingface/tgi",  # This is a Qwen/Qwen3-1.7B hosted in https://endpoints.huggingface.co/mozilla-ai/endpoints/dedicated
+        # Disabling HF/TGI until we sort out the issue with the endpoint not being available because it went to sleep.
+        # Tracked in https://github.com/mozilla-ai/any-agent/issues/744
+        # "huggingface/tgi",  # This is a Qwen/Qwen3-1.7B hosted in https://endpoints.huggingface.co/mozilla-ai/endpoints/dedicated
         "openai/gpt-4.1-nano",
         "xai/grok-3-mini-latest",
         DEFAULT_SMALL_MODEL_ID,


### PR DESCRIPTION
Commented out the "huggingface/tgi" model in the test agent to address the endpoint availability problem. This change is tracked in issue #744.