### PR TITLE
fix(tinyagent): Use `any_llm.acompletion` instead of `completion`.

### DIFF
--- a/src/any_agent/frameworks/tinyagent.py
+++ b/src/any_agent/frameworks/tinyagent.py
@@ -6,7 +6,7 @@ import json
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 
-from any_llm import completion
+from any_llm import acompletion
 from any_llm.provider import ProviderFactory, ProviderName
 from mcp.types import CallToolResult, TextContent
 
@@ -278,7 +278,7 @@ class TinyAgent(AnyAgent):
         )
 
     async def call_model(self, **completion_params: dict[str, Any]) -> ChatCompletion:
-        return completion(**completion_params)  # type: ignore[return-value, arg-type]
+        return await acompletion(**completion_params)  # type: ignore[return-value, arg-type]
 
     async def update_output_type_async(
         self, output_type: type[BaseModel] | None

--- a/src/any_agent/testing/helpers.py
+++ b/src/any_agent/testing/helpers.py
@@ -15,7 +15,7 @@ DEFAULT_SMALL_MODEL_ID = "mistral/mistral-small-latest"
 LITELLM_IMPORT_PATHS = {
     AgentFramework.GOOGLE: "google.adk.models.lite_llm.acompletion",
     AgentFramework.LANGCHAIN: "litellm.acompletion",
-    AgentFramework.TINYAGENT: "any_agent.frameworks.tinyagent.completion",
+    AgentFramework.TINYAGENT: "any_agent.frameworks.tinyagent.acompletion",
     AgentFramework.AGNO: "litellm.acompletion",
     AgentFramework.OPENAI: "litellm.acompletion",
     AgentFramework.SMOLAGENTS: "litellm.completion",


### PR DESCRIPTION
Switching to `completion` meant that there was not a single `await` happening inside tinyagent `_run_async`, causing it to effectively block the async loop until the agent finished.

This was the root issue behind https://github.com/mozilla-ai/agent-factory/pull/292#issuecomment-3213697688