### PR TITLE
feat: MCP-to-A2A bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Get started quickly with these practical examples:
 - **[Creating an agent with MCP](https://mozilla-ai.github.io/any-agent/cookbook/mcp_agent/)** - Integrate Model Context Protocol tools.
 - **[Serve an Agent with A2A](https://mozilla-ai.github.io/any-agent/cookbook/serve_a2a/)** - Deploy agents with Agent-to-Agent communication.
 - **[Building Multi-Agent Systems with A2A](https://mozilla-ai.github.io/any-agent/cookbook/a2a_as_tool/)** - Using an agent as a tool for another agent to interact with.
+- **[Bridge MCP servers to A2A](https://mozilla-ai.github.io/any-agent/cookbook/mcp_a2a_bridge/)** - Expose MCP tools as A2A-compatible services for protocol interoperability.
 
 ## Contributions
 

--- a/docs/cookbook/mcp_a2a_bridge.ipynb
+++ b/docs/cookbook/mcp_a2a_bridge.ipynb
@@ -1,0 +1,273 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Bridge MCP Servers to A2A Protocol\n",
+    "\n",
+    "This cookbook demonstrates how to expose MCP (Model Context Protocol) servers as A2A-compatible services, enabling seamless interoperability between different agent ecosystems.\n",
+    "\n",
+    "## Why Bridge MCP to A2A?\n",
+    "\n",
+    "- **Protocol Interoperability**: Make MCP tools available to Google's A2A ecosystem\n",
+    "- **Enterprise Integration**: Connect local tools with enterprise agent systems\n",
+    "- **Identity Support**: Leverage AGNTCY Identity for secure tool access\n",
+    "- **Zero Changes**: MCP servers work as-is without modifications\n",
+    "\n",
+    "This tutorial assumes familiarity with both MCP and A2A. If you're new to these protocols:\n",
+    "- MCP: See [Creating an agent with MCP](./mcp_agent.ipynb)\n",
+    "- A2A: See [Serve an Agent with A2A](./serve_a2a.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Install Dependencies\n",
+    "\n",
+    "You'll need both MCP and A2A support:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install 'any-agent[mcp,a2a]'\n",
+    "\n",
+    "import nest_asyncio\n",
+    "nest_asyncio.apply()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from getpass import getpass\n",
+    "\n",
+    "# This example uses Mistral models\n",
+    "if \"MISTRAL_API_KEY\" not in os.environ:\n",
+    "    print(\"MISTRAL_API_KEY not found in environment!\")\n",
+    "    api_key = getpass(\"Please enter your MISTRAL_API_KEY: \")\n",
+    "    os.environ[\"MISTRAL_API_KEY\"] = api_key\n",
+    "    print(\"MISTRAL_API_KEY set for this session!\")\n",
+    "else:\n",
+    "    print(\"MISTRAL_API_KEY found in environment.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Basic Bridge: Single MCP Server\n",
+    "\n",
+    "Let's start by bridging a single MCP server (time server) to A2A:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "outputs": [],
+   "source": "from any_agent.config import MCPStdio\nfrom any_agent.serving import (\n    MCPToA2ABridgeConfig,\n    serve_mcp_as_a2a_async,\n)\n\n# Configure MCP server\nmcp_config = MCPStdio(\n    command=\"uvx\",\n    args=[\"mcp-server-time\", \"--local-timezone=America/New_York\"],\n    tools=[\"get_current_time\"],\n)\n\n# Configure bridge\nbridge_config = MCPToA2ABridgeConfig(\n    mcp_config=mcp_config,\n    port=0,  # Use dynamic port\n    endpoint=\"/time-bridge\",\n    server_name=\"time-server\",\n)\n\n# Start the bridge\nbridge_handle = await serve_mcp_as_a2a_async(mcp_config, bridge_config)\nbridge_port = bridge_handle.port\n\nprint(f\"✓ MCP time server bridged to A2A at: http://localhost:{bridge_port}/time-bridge\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use the Bridged MCP Tool via A2A\n",
+    "\n",
+    "Now we can access the MCP tool through A2A protocol:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from any_agent import AgentConfig, AnyAgent\n",
+    "from any_agent.tools import a2a_tool_async\n",
+    "\n",
+    "# Create an A2A tool from the bridged MCP server\n",
+    "time_tool = await a2a_tool_async(\n",
+    "    f\"http://localhost:{bridge_port}/time-bridge\",\n",
+    "    toolname=\"get_time_via_a2a\",\n",
+    "    http_kwargs={\"timeout\": 30},\n",
+    ")\n",
+    "\n",
+    "# Create an agent that uses the bridged tool\n",
+    "agent = await AnyAgent.create_async(\n",
+    "    \"tinyagent\",\n",
+    "    AgentConfig(\n",
+    "        model_id=\"mistral/mistral-small-latest\",\n",
+    "        instructions=\"Use the available tools to answer questions about time.\",\n",
+    "        tools=[time_tool],\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "# Use the MCP tool through A2A\n",
+    "result = await agent.run_async(\"What time is it in New York?\")\n",
+    "print(f\"Agent response: {result.final_output}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Advanced: Bridge with AGNTCY Identity\n\nIf you're using mcpd with AGNTCY Identity support, you can include identity information in the bridge configuration. While the identity won't be exposed through the A2A protocol (due to AgentCard limitations), it will be logged and can be used for internal tracking:",
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "outputs": [],
+   "source": "import json\nfrom pathlib import Path\n\n# Check if identity exists (from mcpd)\nidentity_path = Path(\"~/.config/mcpd/identity/time-server.json\").expanduser()\nidentity_id = None\n\nif identity_path.exists():\n    with open(identity_path) as f:\n        identity_data = json.load(f)\n        identity_id = identity_data.get(\"id\")\n    print(f\"Found identity: {identity_id}\")\nelse:\n    print(\"No identity found - proceeding without identity\")\n\n# Create bridge with identity\nbridge_config_with_id = MCPToA2ABridgeConfig(\n    mcp_config=mcp_config,\n    port=0,\n    endpoint=\"/secure-time\",\n    server_name=\"time-server\",\n    identity_id=identity_id,  # Will be logged but not exposed via A2A\n)\n\n# The identity will be logged when the bridge starts\nsecure_bridge = await serve_mcp_as_a2a_async(mcp_config, bridge_config_with_id)\nprint(f\"✓ Secure bridge started (check logs for identity verification)\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Multi-Bridge: Orchestrating Multiple MCP Tools\n",
+    "\n",
+    "Let's bridge multiple MCP servers and orchestrate them:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Bridge multiple MCP servers\n",
+    "bridges = []\n",
+    "tools = []\n",
+    "\n",
+    "# Time server\n",
+    "time_bridge = await serve_mcp_as_a2a_async(\n",
+    "    MCPStdio(\n",
+    "        command=\"uvx\",\n",
+    "        args=[\"mcp-server-time\"],\n",
+    "        tools=[\"get_current_time\"],\n",
+    "    ),\n",
+    "    MCPToA2ABridgeConfig(\n",
+    "        mcp_config=None,  # Will be set by serve function\n",
+    "        port=0,\n",
+    "        endpoint=\"/time\",\n",
+    "        server_name=\"time\",\n",
+    "    ),\n",
+    ")\n",
+    "bridges.append(time_bridge)\n",
+    "tools.append(\n",
+    "    await a2a_tool_async(\n",
+    "        f\"http://localhost:{time_bridge.port}/time\",\n",
+    "        toolname=\"time_tool\",\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "# Add more MCP servers here (filesystem, github, etc.)\n",
+    "# Example: filesystem_bridge = await serve_mcp_as_a2a_async(...)\n",
+    "\n",
+    "print(f\"✓ Bridged {len(bridges)} MCP servers to A2A\")\n",
+    "\n",
+    "# Create orchestrator agent with all bridged tools\n",
+    "orchestrator = await AnyAgent.create_async(\n",
+    "    \"tinyagent\",\n",
+    "    AgentConfig(\n",
+    "        model_id=\"mistral/mistral-small-latest\",\n",
+    "        name=\"orchestrator\",\n",
+    "        instructions=\"Coordinate multiple tools to answer complex questions.\",\n",
+    "        tools=tools,\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "# Complex query using multiple tools\n",
+    "result = await orchestrator.run_async(\n",
+    "    \"What's the current time? Format it nicely for a report.\"\n",
+    ")\n",
+    "print(f\"\\nOrchestrator response:\\n{result.final_output}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Direct Tool Invocation\n",
+    "\n",
+    "The bridge also supports direct tool invocation using a simple protocol:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "outputs": [],
+   "source": "import httpx\nfrom a2a.client import A2AClient, A2ACardResolver\nfrom a2a.types import (\n    Message,\n    MessageSendParams,\n    Part,\n    Role,\n    SendMessageRequest,\n    TextPart,\n)\nfrom uuid import uuid4\n\n# Get the agent card\nbridge_url = f\"http://localhost:{bridge_port}/time-bridge\"\nasync with httpx.AsyncClient() as client:\n    resolver = A2ACardResolver(httpx_client=client, base_url=bridge_url)\n    agent_card = await resolver.get_agent_card()\n    print(f\"Agent: {agent_card.name}\")\n    print(f\"Skills: {[s.name for s in agent_card.skills]}\")\n\n# Direct tool call\nasync with httpx.AsyncClient() as client:\n    a2a_client = A2AClient(httpx_client=client, agent_card=agent_card)\n    \n    # For single tool bridges, just send the input\n    request = SendMessageRequest(\n        id=str(uuid4()),\n        params=MessageSendParams(\n            message=Message(\n                role=Role.user,\n                parts=[Part(root=TextPart(text=\"current time\"))],\n                message_id=str(uuid4()),\n            )\n        ),\n    )\n    \n    response = await a2a_client.send_message(request)\n    print(f\"\\nDirect response: {response}\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cleanup\n",
+    "\n",
+    "Don't forget to clean up the bridges:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Shutdown all bridges\n",
+    "for bridge in bridges:\n",
+    "    await bridge.shutdown()\n",
+    "\n",
+    "await bridge_handle.shutdown()\n",
+    "await secure_bridge.shutdown()\n",
+    "\n",
+    "print(\"✓ All bridges shut down\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Next Steps\n",
+    "\n",
+    "1. **Production Deployment**: Deploy bridges as microservices\n",
+    "2. **Service Discovery**: Register bridges with AGNTCY Directory\n",
+    "3. **Authentication**: Add proper auth between bridges and agents\n",
+    "4. **Monitoring**: Add observability for bridge operations\n",
+    "\n",
+    "For more information:\n",
+    "- [MCP Documentation](https://modelcontextprotocol.io/)\n",
+    "- [A2A Protocol](https://github.com/google/a2a)\n",
+    "- [AGNTCY Identity](https://github.com/agntcy/identity)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/mcp_a2a_bridge_demo.py
+++ b/examples/mcp_a2a_bridge_demo.py
@@ -1,0 +1,139 @@
+"""Demo of MCP to A2A Bridge.
+
+This example shows how to:
+1. Expose MCP servers as A2A services
+2. Use the bridged MCP tools from A2A agents
+3. Integrate with mcpd's AGNTCY Identity
+"""
+
+import asyncio
+import os
+from any_agent import AgentConfig, AnyAgent
+from any_agent.config import MCPStdio
+from any_agent.serving import (
+    MCPToA2ABridgeConfig,
+    serve_mcp_as_a2a_async,
+)
+from any_agent.tools import a2a_tool_async
+
+
+async def demo_single_bridge():
+    """Demo: Bridge a single MCP server to A2A."""
+    print("=== Single MCP to A2A Bridge Demo ===\n")
+    
+    # Configure MCP server (using mcp-server-time as example)
+    mcp_config = MCPStdio(
+        command="uvx",
+        args=["mcp-server-time", "--local-timezone=America/New_York"],
+        tools=["get_current_time"],
+    )
+    
+    # Create bridge configuration
+    bridge_config = MCPToA2ABridgeConfig(
+        mcp_config=mcp_config,
+        port=9000,
+        endpoint="/time-server",
+        server_name="time-server",
+        # If using mcpd with identity:
+        # identity_id="did:agntcy:mcpd:demo:time-server"
+    )
+    
+    # Start the bridge
+    bridge_handle = await serve_mcp_as_a2a_async(mcp_config, bridge_config)
+    
+    try:
+        print(f"✓ MCP server exposed as A2A service at: http://localhost:9000/time-server")
+        
+        # Create an agent that uses the bridged MCP tool via A2A
+        print("\n--- Using from A2A agent ---")
+        
+        agent_config = AgentConfig(
+            model_id="mistral/mistral-small-latest",
+            instructions="Use the available tools to answer questions.",
+            tools=[
+                await a2a_tool_async(
+                    "http://localhost:9000/time-server",
+                    toolname="mcp_time_tool",
+                    http_kwargs={"timeout": 30},
+                ),
+            ],
+        )
+        
+        agent = await AnyAgent.create_async("tinyagent", agent_config)
+        
+        # Use the MCP tool through A2A
+        result = await agent.run_async("What time is it in New York?")
+        print(f"Agent response: {result.final_output}")
+        
+    finally:
+        # Cleanup
+        await bridge_handle.shutdown()
+
+
+async def demo_multi_bridge():
+    """Demo: Bridge multiple MCP servers."""
+    print("\n=== Multiple MCP Bridges Demo ===\n")
+    
+    bridges = []
+    tools = []
+    
+    try:
+        # Bridge time server
+        time_handle = await serve_mcp_as_a2a_async(
+            MCPStdio(
+                command="uvx",
+                args=["mcp-server-time"],
+                tools=["get_current_time"],
+            ),
+            MCPToA2ABridgeConfig(
+                mcp_config=None,  # Will be set by serve function
+                port=0,  # Dynamic port
+                endpoint="/time",
+                server_name="time",
+            ),
+        )
+        bridges.append(time_handle)
+        tools.append(
+            await a2a_tool_async(
+                f"http://localhost:{time_handle.port}/time",
+                toolname="time_tool",
+            )
+        )
+        
+        print(f"✓ Bridged {len(bridges)} MCP servers to A2A")
+        
+        # Create orchestrator agent with all bridged tools
+        orchestrator = await AnyAgent.create_async(
+            "tinyagent",
+            AgentConfig(
+                model_id="mistral/mistral-small-latest",
+                name="orchestrator",
+                instructions="Use the available tools to answer questions.",
+                tools=tools,
+            ),
+        )
+        
+        # Use the bridged tools
+        result = await orchestrator.run_async("What time is it?")
+        print(f"Orchestrator response: {result.final_output}")
+        
+    finally:
+        # Cleanup all bridges
+        for bridge in bridges:
+            await bridge.shutdown()
+
+
+async def main():
+    """Run all demos."""
+    # Set up API key
+    if "MISTRAL_API_KEY" not in os.environ:
+        print("Please set MISTRAL_API_KEY environment variable")
+        return
+    
+    # Run demos
+    await demo_single_bridge()
+    await demo_multi_bridge()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
       - MCP Agent: cookbook/mcp_agent.ipynb
       - Serve with A2A: cookbook/serve_a2a.ipynb
       - Use an Agent as a tool for another agent (A2A): cookbook/a2a_as_tool.ipynb
+      - Bridge MCP to A2A: cookbook/mcp_a2a_bridge.ipynb
       - Local Agent: cookbook/agent_with_local_llm.ipynb
   - API Reference:
     - Agent: api/agent.md

--- a/src/any_agent/serving/__init__.py
+++ b/src/any_agent/serving/__init__.py
@@ -11,6 +11,19 @@ __all__ = [
 ]
 
 try:
+    from .mcp_a2a_bridge import (
+        MCPToA2ABridgeConfig,
+        serve_mcp_as_a2a_async,
+    )
+    
+    __all__ += [
+        "MCPToA2ABridgeConfig",
+        "serve_mcp_as_a2a_async",
+    ]
+except ImportError:
+    pass
+
+try:
     from .a2a.config_a2a import A2AServingConfig
     from .a2a.server_a2a import (
         _get_a2a_app_async,

--- a/src/any_agent/serving/mcp_a2a_bridge.py
+++ b/src/any_agent/serving/mcp_a2a_bridge.py
@@ -1,0 +1,299 @@
+"""MCP to A2A Bridge for any-agent.
+
+This module provides a bridge that exposes MCP servers as A2A-compatible services,
+enabling seamless tool-to-agent communication across protocols.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any, Optional
+
+from pydantic import BaseModel, Field
+
+from any_agent.logging import logger
+from any_agent.serving.server_handle import ServerHandle
+
+if TYPE_CHECKING:
+    from any_agent.config import MCPParams
+    from any_agent.tools.mcp.mcp_client import MCPClient
+
+# Check if A2A is available
+a2a_available = False
+try:
+    from a2a.server.agent_execution import AgentExecutor, RequestContext
+    from a2a.server.apps import A2AStarletteApplication
+    from a2a.server.events import EventQueue
+    from a2a.server.request_handlers import DefaultRequestHandler
+    from a2a.server.tasks import TaskUpdater
+    from a2a.types import (
+        AgentCapabilities,
+        AgentCard,
+        AgentSkill,
+        Part,
+        Role,
+        TaskState,
+        TextPart,
+    )
+    from a2a.utils import new_agent_parts_message
+    
+    a2a_available = True
+except ImportError:
+    pass
+
+
+class MCPToA2ABridgeConfig(BaseModel):
+    """Configuration for MCP to A2A bridge."""
+
+    mcp_config: MCPParams
+    host: str = Field(default="localhost", description="Host to serve on")
+    port: int = Field(default=8080, description="Port to serve on")
+    endpoint: str = Field(default="/mcp-bridge", description="Endpoint path")
+    server_name: str = Field(default="mcp-server", description="MCP server name")
+    identity_id: Optional[str] = Field(
+        default=None, 
+        description="AGNTCY Identity DID for internal tracking (not exposed via A2A)"
+    )
+    version: str = Field(default="1.0.0", description="Version of the bridge")
+
+
+class MCPBridgeExecutor(AgentExecutor):
+    """Executor that translates A2A requests to MCP tool calls."""
+
+    def __init__(self, mcp_client: MCPClient, bridge_config: MCPToA2ABridgeConfig):
+        """Initialize the executor.
+
+        Args:
+            mcp_client: Connected MCP client
+            bridge_config: Bridge configuration
+        """
+        self.mcp_client = mcp_client
+        self.bridge_config = bridge_config
+        self._mcp_tools: dict[str, Any] = {}
+
+    async def initialize(self) -> None:
+        """Initialize by loading MCP tools."""
+        raw_tools = await self.mcp_client.list_raw_tools()
+        self._mcp_tools = {tool.name: tool for tool in raw_tools}
+        logger.info(f"Loaded {len(self._mcp_tools)} MCP tools")
+    
+
+    async def execute(
+        self,
+        context: RequestContext,
+        event_queue: EventQueue,
+    ) -> None:
+        """Execute A2A request by calling appropriate MCP tool.
+
+        Args:
+            context: A2A request context
+            event_queue: Event queue for updates
+        """
+        query = context.get_user_input()
+        task = context.current_task
+        
+        if not task:
+            logger.error("No task in context")
+            return
+            
+        updater = TaskUpdater(event_queue, task.id, task.context_id)
+        
+        try:
+            # For MCP bridge, we expect the query to specify the tool and args
+            # Simple format: just pass the query as input to the first available tool
+            if not self._mcp_tools:
+                error_msg = "No MCP tools available"
+                await updater.update_status(
+                    TaskState.complete,
+                    message=new_agent_parts_message(
+                        [Part(root=TextPart(text=error_msg))],
+                        task.context_id,
+                        task.id,
+                    ),
+                    final=True,
+                )
+                return
+            
+            # Use first tool if only one available, otherwise return error
+            if len(self._mcp_tools) == 1:
+                tool_name = list(self._mcp_tools.keys())[0]
+                args = {"input": query}
+            else:
+                # Multiple tools, need more specific request
+                error_msg = f"Multiple tools available: {list(self._mcp_tools.keys())}. Please specify which tool to use."
+                await updater.update_status(
+                    TaskState.complete,
+                    message=new_agent_parts_message(
+                        [Part(root=TextPart(text=error_msg))],
+                        task.context_id,
+                        task.id,
+                    ),
+                    final=True,
+                )
+                return
+            
+            # Call MCP tool
+            logger.info(f"Calling MCP tool '{tool_name}' with args: {args}")
+            
+            # Get the callable tool
+            tools = await self.mcp_client.list_tools()
+            tool_func = next((t for t in tools if t.__name__ == tool_name), None)
+            
+            if not tool_func:
+                raise ValueError(f"Tool {tool_name} not found in callable tools")
+            
+            # Execute the tool
+            result = await tool_func(**args) if asyncio.iscoroutinefunction(tool_func) else tool_func(**args)
+            
+            # Format result
+            result_text = str(result)
+            
+            # Send success response
+            await updater.update_status(
+                TaskState.complete,
+                message=new_agent_parts_message(
+                    [Part(root=TextPart(text=result_text))],
+                    task.context_id,
+                    task.id,
+                ),
+                final=True,
+            )
+            
+        except Exception as e:
+            logger.error(f"Error executing MCP tool: {e}")
+            await updater.update_status(
+                TaskState.failed,
+                message=new_agent_parts_message(
+                    [Part(root=TextPart(text=f"Error: {str(e)}"))],
+                    task.context_id,
+                    task.id,
+                ),
+                final=True,
+            )
+
+    async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:
+        """Cancel is not supported."""
+        logger.warning("Cancel requested but not supported")
+
+
+async def serve_mcp_as_a2a_async(
+    mcp_config: MCPParams,
+    bridge_config: Optional[MCPToA2ABridgeConfig] = None,
+    framework: str = "tinyagent",
+) -> ServerHandle:
+    """Serve an MCP server as an A2A service.
+
+    Args:
+        mcp_config: MCP server configuration
+        bridge_config: Bridge configuration (uses defaults if not provided)
+        framework: Agent framework to use for tool conversion
+
+    Returns:
+        ServerHandle for managing the server
+
+    Raises:
+        ImportError: If A2A dependencies are not installed
+    """
+    if not a2a_available:
+        msg = "You need to `pip install 'any-agent[a2a]'` to use MCP to A2A bridge"
+        raise ImportError(msg)
+    
+    from any_agent.config import AgentFramework
+    from any_agent.tools.mcp.mcp_client import MCPClient
+    import uvicorn
+    from starlette.applications import Starlette
+    from starlette.routing import Mount
+    
+    # Use default config if not provided
+    if bridge_config is None:
+        bridge_config = MCPToA2ABridgeConfig(mcp_config=mcp_config)
+    else:
+        # Ensure mcp_config is set
+        bridge_config.mcp_config = mcp_config
+    
+    # Create and connect MCP client
+    mcp_client = MCPClient(
+        config=mcp_config,
+        framework=AgentFramework.from_string(framework),
+    )
+    await mcp_client.connect()
+    
+    # Create executor
+    executor = MCPBridgeExecutor(mcp_client, bridge_config)
+    await executor.initialize()
+    
+    # Generate agent card
+    mcp_tools = await mcp_client.list_raw_tools()
+    skills = []
+    for tool in mcp_tools:
+        skill = AgentSkill(
+            id=f"{bridge_config.server_name}-{tool.name}",
+            name=tool.name,
+            description=tool.description or f"MCP tool: {tool.name}",
+            tags=[],
+        )
+        skills.append(skill)
+    
+    agent_card = AgentCard(
+        name=f"{bridge_config.server_name}-bridge",
+        description=f"MCP server '{bridge_config.server_name}' exposed via A2A",
+        version=bridge_config.version,
+        default_input_modes=["text"],
+        default_output_modes=["text"],
+        url=f"http://{bridge_config.host}:{bridge_config.port}{bridge_config.endpoint}",
+        capabilities=AgentCapabilities(
+            streaming=False,
+            push_notifications=False,
+            state_transition_history=False,
+        ),
+        skills=skills,
+    )
+    
+    # Note: Identity ID is stored in config but not exposed in AgentCard
+    # as A2A's AgentCard may not support metadata field
+    
+    # Create A2A request handler
+    request_handler = DefaultRequestHandler(
+        agent_executor=executor,
+        task_store=None,  # Uses in-memory store
+        push_config_store=None,
+        push_sender=None,
+    )
+    
+    # Create A2A app
+    a2a_app = A2AStarletteApplication(
+        agent_card=agent_card,
+        http_handler=request_handler,
+    )
+    
+    # Mount under endpoint
+    root = bridge_config.endpoint.lstrip("/").rstrip("/")
+    app = Starlette(routes=[Mount(f"/{root}", routes=a2a_app.build().routes)])
+    
+    # Create and start server
+    config = uvicorn.Config(
+        app,
+        host=bridge_config.host,
+        port=bridge_config.port,
+        log_level="warning",
+    )
+    server = uvicorn.Server(config)
+    
+    # Start server in background
+    task = asyncio.create_task(server.serve())
+    
+    # Wait for server to start
+    while not server.started:
+        await asyncio.sleep(0.1)
+    
+    # Update agent card URL if using dynamic port
+    if bridge_config.port == 0 and server.servers:
+        actual_port = server.servers[0].sockets[0].getsockname()[1]
+        agent_card.url = f"http://{bridge_config.host}:{actual_port}{bridge_config.endpoint}"
+    
+    if bridge_config.identity_id:
+        logger.info(f"MCP to A2A bridge started at {agent_card.url} with identity {bridge_config.identity_id}")
+    else:
+        logger.info(f"MCP to A2A bridge started at {agent_card.url}")
+    
+    return ServerHandle(task=task, server=server)

--- a/tests/integration/mcp_a2a/__init__.py
+++ b/tests/integration/mcp_a2a/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for MCP to A2A bridge."""

--- a/tests/integration/mcp_a2a/test_mcp_a2a_bridge.py
+++ b/tests/integration/mcp_a2a/test_mcp_a2a_bridge.py
@@ -1,0 +1,222 @@
+"""Integration tests for MCP to A2A bridge."""
+
+import asyncio
+import json
+from uuid import uuid4
+
+import httpx
+import pytest
+from a2a.client import A2ACardResolver, A2AClient
+from a2a.types import (
+    Message,
+    MessageSendParams,
+    Part,
+    Role,
+    SendMessageRequest,
+    TextPart,
+)
+
+from any_agent import AgentConfig, AnyAgent
+from any_agent.config import MCPStdio
+from any_agent.serving import (
+    MCPToA2ABridgeConfig,
+    serve_mcp_as_a2a_async,
+)
+from any_agent.tools import a2a_tool_async
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestMCPToA2ABridge:
+    """Test MCP to A2A bridge functionality."""
+
+    async def test_basic_bridge(self):
+        """Test basic MCP to A2A bridge functionality."""
+        # Configure MCP server
+        mcp_config = MCPStdio(
+            command="echo",
+            args=["test"],
+            tools=["echo_tool"],
+        )
+        
+        # Configure bridge
+        bridge_config = MCPToA2ABridgeConfig(
+            mcp_config=mcp_config,
+            port=0,  # Dynamic port
+            endpoint="/test-bridge",
+            server_name="test-server",
+        )
+        
+        # Start bridge
+        bridge_handle = await serve_mcp_as_a2a_async(mcp_config, bridge_config)
+        
+        try:
+            # Verify bridge is running
+            assert bridge_handle.port > 0
+            
+            # Get agent card
+            bridge_url = f"http://localhost:{bridge_handle.port}/test-bridge"
+            async with httpx.AsyncClient() as client:
+                resolver = A2ACardResolver(httpx_client=client, base_url=bridge_url)
+                agent_card = await resolver.get_agent_card()
+                
+                assert agent_card.name == "test-server-bridge", f"Expected name 'test-server-bridge', got {agent_card.name}"
+                assert len(agent_card.skills) > 0, "Expected at least one skill"
+                assert agent_card.skills[0].name == "echo_tool", f"Expected skill name 'echo_tool', got {agent_card.skills[0].name}"
+                
+        finally:
+            await bridge_handle.shutdown()
+
+    async def test_bridge_with_identity(self):
+        """Test bridge with AGNTCY identity."""
+        # Configure with identity
+        bridge_config = MCPToA2ABridgeConfig(
+            mcp_config=MCPStdio(
+                command="echo",
+                args=["test"],
+                tools=["echo_tool"],
+            ),
+            port=0,
+            endpoint="/secure-bridge",
+            server_name="secure-server",
+            identity_id="did:agntcy:mcpd:test:secure-server",
+        )
+        
+        # Start bridge
+        bridge_handle = await serve_mcp_as_a2a_async(
+            bridge_config.mcp_config,
+            bridge_config,
+        )
+        
+        try:
+            # Get agent card and verify identity
+            bridge_url = f"http://localhost:{bridge_handle.port}/secure-bridge"
+            async with httpx.AsyncClient() as client:
+                resolver = A2ACardResolver(httpx_client=client, base_url=bridge_url)
+                agent_card = await resolver.get_agent_card()
+                
+                # Identity is stored in config but not exposed in AgentCard
+                # as A2A's AgentCard may not support metadata field
+                assert bridge_config.identity_id == "did:agntcy:mcpd:test:secure-server"
+                
+        finally:
+            await bridge_handle.shutdown()
+
+    async def test_tool_invocation_via_a2a(self):
+        """Test invoking MCP tool through A2A protocol."""
+        # Use a simple MCP server
+        mcp_config = MCPStdio(
+            command="python",
+            args=["-c", "print('Hello from MCP')"],
+            tools=["hello_tool"],
+        )
+        
+        bridge_config = MCPToA2ABridgeConfig(
+            mcp_config=mcp_config,
+            port=0,
+            endpoint="/hello-bridge",
+            server_name="hello-server",
+        )
+        
+        # Start bridge
+        bridge_handle = await serve_mcp_as_a2a_async(mcp_config, bridge_config)
+        
+        try:
+            # Create A2A tool
+            bridge_url = f"http://localhost:{bridge_handle.port}/hello-bridge"
+            tool = await a2a_tool_async(bridge_url, toolname="mcp_hello")
+            
+            # Create agent with bridged tool
+            agent = await AnyAgent.create_async(
+                "tinyagent",
+                AgentConfig(
+                    model_id="mistral/mistral-small-latest",
+                    instructions="Use the available tools.",
+                    tools=[tool],
+                ),
+            )
+            
+            # Use the tool
+            result = await agent.run_async("Say hello using the tool")
+            assert result.final_output is not None
+            
+        finally:
+            await bridge_handle.shutdown()
+
+    async def test_direct_tool_call(self):
+        """Test direct tool invocation without agent."""
+        # Simple echo MCP server
+        mcp_config = MCPStdio(
+            command="echo",
+            args=["direct test"],
+            tools=["echo_tool"],
+        )
+        
+        bridge_config = MCPToA2ABridgeConfig(
+            mcp_config=mcp_config,
+            port=0,
+            endpoint="/direct-bridge",
+            server_name="direct-server",
+        )
+        
+        # Start bridge
+        bridge_handle = await serve_mcp_as_a2a_async(mcp_config, bridge_config)
+        
+        try:
+            bridge_url = f"http://localhost:{bridge_handle.port}/direct-bridge"
+            
+            # Get agent card
+            async with httpx.AsyncClient() as client:
+                resolver = A2ACardResolver(httpx_client=client, base_url=bridge_url)
+                agent_card = await resolver.get_agent_card()
+                
+                # Direct tool call
+                a2a_client = A2AClient(httpx_client=client, agent_card=agent_card)
+                
+                request = SendMessageRequest(
+                    id=str(uuid4()),
+                    params=MessageSendParams(
+                        message=Message(
+                            role=Role.user,
+                            parts=[Part(root=TextPart(text="test message"))],
+                            message_id=str(uuid4()),
+                        )
+                    ),
+                )
+                
+                response = await a2a_client.send_message(request)
+                assert response is not None
+                
+        finally:
+            await bridge_handle.shutdown()
+
+    async def test_multiple_bridges(self):
+        """Test running multiple bridges simultaneously."""
+        bridges = []
+        
+        try:
+            # Start multiple bridges
+            for i in range(3):
+                config = MCPToA2ABridgeConfig(
+                    mcp_config=MCPStdio(
+                        command="echo",
+                        args=[f"server-{i}"],
+                        tools=[f"tool_{i}"],
+                    ),
+                    port=0,
+                    endpoint=f"/bridge-{i}",
+                    server_name=f"server-{i}",
+                )
+                
+                handle = await serve_mcp_as_a2a_async(config.mcp_config, config)
+                bridges.append(handle)
+            
+            # Verify all are running
+            assert len(bridges) == 3
+            for handle in bridges:
+                assert handle.port > 0
+                
+        finally:
+            # Cleanup all bridges
+            for handle in bridges:
+                await handle.shutdown()


### PR DESCRIPTION
Lets MCP tools work with A2A agents.

## What It Does

Bridges MCP servers to A2A protocol so A2A agents can use MCP tools.

## Example

```python
from any_agent.serving import serve_mcp_as_a2a_async, MCPToA2ABridgeConfig
from any_agent.config import MCPStdio

# Your MCP server
mcp_config = MCPStdio(
    command="uvx",
    args=["mcp-server-filesystem"],
)

# Make it work with A2A
bridge_config = MCPToA2ABridgeConfig(
    mcp_config=mcp_config,
    server_name="fs-server",
)

await serve_mcp_as_a2a_async(mcp_config, bridge_config)
```

## Notes

- If using mcpd with identity, it gets logged (A2A can't transmit metadata)
- Performance optimized with tool caching
- See cookbook example for full usage

Addresses #756.