### PR TITLE
feat: MCP-to-ACP bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ A single interface to use and evaluate different agent frameworks.
 
 [![TinyAgent](https://img.shields.io/badge/TinyAgent-ffcb3a?logo=huggingface&logoColor=white)](https://huggingface.co/blog/tiny-agents) [![Google ADK](https://img.shields.io/badge/Google%20ADK-4285F4?logo=google&logoColor=white)](https://github.com/google/adk-python) [![LangChain](https://img.shields.io/badge/LangChain-1e4545?logo=langchain&logoColor=white)](https://github.com/langchain-ai/langgraph) [![LlamaIndex](https://img.shields.io/badge/🦙%20LlamaIndex-fbcfe2)](https://github.com/run-llama/llama_index) [![OpenAI Agents](https://img.shields.io/badge/OpenAI%20Agents-black?logo=openai)](https://github.com/openai/openai-agents-python) [![Smolagents](https://img.shields.io/badge/Smolagents-ffcb3a?logo=huggingface&logoColor=white)](https://github.com/huggingface/smolagents) [![Agno AI](https://img.shields.io/badge/Agno-ff4017)](https://github.com/agno-agi/agno)
 
+## Protocol Bridging
+
+any-agent supports bridging between different agent communication protocols:
+
+- **MCP → A2A**: Expose Model Context Protocol servers as Google's Agent-to-Agent services
+- **MCP → ACP**: Expose Model Context Protocol servers as Linux Foundation AGNTCY's Agent Connect Protocol services with W3C DID identity support
+
 
 
 ### Planned for Support (Contributions Welcome!)
@@ -93,6 +100,7 @@ Get started quickly with these practical examples:
 - **[Creating an agent with MCP](https://mozilla-ai.github.io/any-agent/cookbook/mcp_agent/)** - Integrate Model Context Protocol tools.
 - **[Serve an Agent with A2A](https://mozilla-ai.github.io/any-agent/cookbook/serve_a2a/)** - Deploy agents with Agent-to-Agent communication.
 - **[Building Multi-Agent Systems with A2A](https://mozilla-ai.github.io/any-agent/cookbook/a2a_as_tool/)** - Using an agent as a tool for another agent to interact with.
+- **[Bridge MCP servers to ACP](https://mozilla-ai.github.io/any-agent/cookbook/mcp_acp_bridge/)** - Expose MCP tools as ACP-compatible services with AGNTCY Identity support.
 
 ## Contributions
 

--- a/docs/cookbook/mcp_acp_bridge.ipynb
+++ b/docs/cookbook/mcp_acp_bridge.ipynb
@@ -1,0 +1,318 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Bridge MCP servers to ACP\n",
+    "\n",
+    "This cookbook demonstrates how to use any-agent's MCP-to-ACP bridge to expose Model Context Protocol (MCP) servers as Agent Connect Protocol (ACP) compatible services.\n",
+    "\n",
+    "## Why Bridge MCP to ACP?\n",
+    "\n",
+    "- **Protocol Interoperability**: Make MCP tools available to Linux Foundation's AGNTCY ecosystem\n",
+    "- **Enterprise Integration**: Connect local tools with enterprise agent systems\n",
+    "- **Identity Support**: Leverage AGNTCY Identity (W3C DIDs) for secure tool access\n",
+    "- **Standards Compliance**: Support for W3C Decentralized Identifiers and Verifiable Credentials\n",
+    "\n",
+    "## Prerequisites\n",
+    "\n",
+    "You'll need to install the ACP SDK:\n",
+    "\n",
+    "```bash\n",
+    "pip install agntcy-acp\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For Jupyter notebooks\n",
+    "import nest_asyncio\n",
+    "nest_asyncio.apply()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 1: Basic MCP to ACP Bridge\n",
+    "\n",
+    "Let's start by bridging a simple MCP time server to ACP:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asyncio\n",
+    "from any_agent.config import MCPStdio\n",
+    "from any_agent.serving import (\n",
+    "    MCPToACPBridgeConfig,\n",
+    "    serve_mcp_as_acp_async,\n",
+    ")\n",
+    "\n",
+    "async def bridge_time_server():\n",
+    "    # Configure MCP server\n",
+    "    mcp_config = MCPStdio(\n",
+    "        command=\"uvx\",\n",
+    "        args=[\"mcp-server-time\"],\n",
+    "        tools=[\"get_current_time\"],\n",
+    "    )\n",
+    "    \n",
+    "    # Configure bridge\n",
+    "    bridge_config = MCPToACPBridgeConfig(\n",
+    "        mcp_config=mcp_config,\n",
+    "        port=8090,\n",
+    "        endpoint=\"/time-bridge\",\n",
+    "        server_name=\"time-server\",\n",
+    "        organization=\"any-agent-demo\",\n",
+    "        version=\"1.0.0\",\n",
+    "    )\n",
+    "    \n",
+    "    # Start the bridge\n",
+    "    print(\"Starting MCP to ACP bridge...\")\n",
+    "    bridge_handle = await serve_mcp_as_acp_async(mcp_config, bridge_config)\n",
+    "    \n",
+    "    print(f\"✓ MCP server bridged to ACP at: http://localhost:8090/time-bridge\")\n",
+    "    print(f\"  - ACP agents endpoint: http://localhost:8090/time-bridge/agents\")\n",
+    "    print(f\"  - Stateless runs endpoint: http://localhost:8090/time-bridge/runs/stateless\")\n",
+    "    \n",
+    "    return bridge_handle\n",
+    "\n",
+    "# Start the bridge (run in background)\n",
+    "bridge_task = asyncio.create_task(bridge_time_server())\n",
+    "bridge_handle = await bridge_task\n",
+    "print(\"\\nBridge is running!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 2: Using the Bridged MCP Tool via ACP\n",
+    "\n",
+    "Now let's use the bridged MCP tool through the ACP protocol:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from agntcy_acp import ACPAsyncClient, RunCreateStateless\n",
+    "\n",
+    "async def use_bridged_tool():\n",
+    "    # Create ACP client\n",
+    "    client = ACPAsyncClient(base_url=\"http://localhost:8090/time-bridge\")\n",
+    "    \n",
+    "    # List available agents\n",
+    "    print(\"Listing available agents...\")\n",
+    "    agents = await client.list_agents()\n",
+    "    for agent in agents:\n",
+    "        print(f\"  - Agent ID: {agent.id}\")\n",
+    "        print(f\"    Name: {agent.name}\")\n",
+    "        print(f\"    Description: {agent.description}\")\n",
+    "    \n",
+    "    # Create a stateless run to get the current time\n",
+    "    print(\"\\nCalling get_current_time tool...\")\n",
+    "    run_request = RunCreateStateless(\n",
+    "        config={\n",
+    "            \"tool\": \"get_current_time\",\n",
+    "            \"args\": {}\n",
+    "        }\n",
+    "    )\n",
+    "    \n",
+    "    result = await client.create_stateless_run(\n",
+    "        agent_id=\"mcp-bridge-time-server\",\n",
+    "        run_request=run_request\n",
+    "    )\n",
+    "    \n",
+    "    print(f\"\\nResult:\")\n",
+    "    print(f\"  Status: {result.status}\")\n",
+    "    print(f\"  Output: {result.output}\")\n",
+    "\n",
+    "await use_bridged_tool()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 3: Bridge with AGNTCY Identity\n",
+    "\n",
+    "This example shows how to configure the bridge with AGNTCY Identity support:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def bridge_with_identity():\n",
+    "    # Configure MCP server\n",
+    "    mcp_config = MCPStdio(\n",
+    "        command=\"uvx\",\n",
+    "        args=[\"mcp-server-filesystem\"],\n",
+    "        tools=[\"read_file\", \"write_file\", \"list_files\"],\n",
+    "    )\n",
+    "    \n",
+    "    # Configure bridge with identity\n",
+    "    bridge_config = MCPToACPBridgeConfig(\n",
+    "        mcp_config=mcp_config,\n",
+    "        port=8091,\n",
+    "        endpoint=\"/fs-bridge\",\n",
+    "        server_name=\"filesystem-server\",\n",
+    "        # W3C DID for AGNTCY Identity\n",
+    "        identity_id=\"did:agntcy:example:filesystem-bridge-123\",\n",
+    "        organization=\"secure-tools-org\",\n",
+    "        version=\"1.0.0\",\n",
+    "    )\n",
+    "    \n",
+    "    # Start the bridge\n",
+    "    print(\"Starting MCP to ACP bridge with AGNTCY Identity...\")\n",
+    "    bridge_handle = await serve_mcp_as_acp_async(mcp_config, bridge_config)\n",
+    "    \n",
+    "    print(f\"\\n✓ Secure MCP server bridged to ACP\")\n",
+    "    print(f\"  - Endpoint: http://localhost:8091/fs-bridge\")\n",
+    "    print(f\"  - Identity DID: {bridge_config.identity_id}\")\n",
+    "    print(f\"  - Organization: {bridge_config.organization}\")\n",
+    "    \n",
+    "    return bridge_handle\n",
+    "\n",
+    "# Uncomment to run\n",
+    "# secure_bridge = await bridge_with_identity()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 4: Multiple MCP Tools via ACP\n",
+    "\n",
+    "When an MCP server has multiple tools, you can specify which tool to call:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def call_specific_tool():\n",
+    "    client = ACPAsyncClient(base_url=\"http://localhost:8091/fs-bridge\")\n",
+    "    \n",
+    "    # List files in current directory\n",
+    "    print(\"Listing files...\")\n",
+    "    list_request = RunCreateStateless(\n",
+    "        config={\n",
+    "            \"tool\": \"list_files\",\n",
+    "            \"args\": {\n",
+    "                \"path\": \".\"\n",
+    "            }\n",
+    "        }\n",
+    "    )\n",
+    "    \n",
+    "    result = await client.create_stateless_run(\n",
+    "        agent_id=\"mcp-bridge-filesystem-server\",\n",
+    "        run_request=list_request\n",
+    "    )\n",
+    "    \n",
+    "    print(f\"Files: {result.output}\")\n",
+    "    \n",
+    "    # Read a specific file\n",
+    "    print(\"\\nReading README.md...\")\n",
+    "    read_request = RunCreateStateless(\n",
+    "        config={\n",
+    "            \"tool\": \"read_file\",\n",
+    "            \"args\": {\n",
+    "                \"path\": \"README.md\"\n",
+    "            }\n",
+    "        }\n",
+    "    )\n",
+    "    \n",
+    "    result = await client.create_stateless_run(\n",
+    "        agent_id=\"mcp-bridge-filesystem-server\",\n",
+    "        run_request=read_request\n",
+    "    )\n",
+    "    \n",
+    "    print(f\"Content preview: {str(result.output)[:200]}...\")\n",
+    "\n",
+    "# Uncomment if filesystem bridge is running\n",
+    "# await call_specific_tool()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Clean Up\n",
+    "\n",
+    "Stop the bridge servers when done:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Stop the bridge\n",
+    "if 'bridge_handle' in locals() and bridge_handle:\n",
+    "    bridge_handle.server.should_exit = True\n",
+    "    await asyncio.sleep(1)\n",
+    "    print(\"Bridge stopped.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "In this cookbook, we've demonstrated:\n",
+    "\n",
+    "1. **Basic Bridge Setup**: How to expose an MCP server via ACP protocol\n",
+    "2. **Using Bridged Tools**: How to call MCP tools through the ACP client\n",
+    "3. **Identity Integration**: Adding AGNTCY Identity (W3C DIDs) to bridges\n",
+    "4. **Multi-Tool Support**: Working with MCP servers that have multiple tools\n",
+    "\n",
+    "The MCP-to-ACP bridge enables seamless interoperability between Mozilla's MCP ecosystem and Linux Foundation's AGNTCY platform, supporting enterprise integration scenarios with secure identity management.\n",
+    "\n",
+    "## Next Steps\n",
+    "\n",
+    "- Learn more about [AGNTCY Identity](https://spec.identity.agntcy.org/)\n",
+    "- Explore [W3C DIDs](https://www.w3.org/TR/did-core/) and [Verifiable Credentials](https://www.w3.org/TR/vc-data-model/)\n",
+    "- Check out the [Linux Foundation AGNTCY Project](https://www.linuxfoundation.org/press/linux-foundation-welcomes-the-agntcy-project-to-standardize-open-multi-agent-system-infrastructure-and-break-down-ai-agent-silos)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/src/any_agent/serving/__init__.py
+++ b/src/any_agent/serving/__init__.py
@@ -11,6 +11,19 @@ __all__ = [
 ]
 
 try:
+    from .mcp_acp_bridge import (
+        MCPToACPBridgeConfig,
+        serve_mcp_as_acp_async,
+    )
+    
+    __all__ += [
+        "MCPToACPBridgeConfig",
+        "serve_mcp_as_acp_async",
+    ]
+except ImportError:
+    pass
+
+try:
     from .a2a.config_a2a import A2AServingConfig
     from .a2a.server_a2a import (
         _get_a2a_app_async,

--- a/src/any_agent/serving/mcp_acp_bridge.py
+++ b/src/any_agent/serving/mcp_acp_bridge.py
@@ -72,12 +72,19 @@ class MCPBridgeExecutor:
         self.mcp_client = mcp_client
         self.bridge_config = bridge_config
         self._mcp_tools: dict[str, Any] = {}
+        self._callable_tools: list[Any] = []
+        self._tool_map: dict[str, Any] = {}
         self._agent_manifest: Optional[dict[str, Any]] = None
 
     async def initialize(self) -> None:
         """Initialize by loading MCP tools and creating ACP manifest."""
         raw_tools = await self.mcp_client.list_raw_tools()
         self._mcp_tools = {tool.name: tool for tool in raw_tools}
+        
+        # Cache callable tools for performance
+        self._callable_tools = await self.mcp_client.list_tools()
+        self._tool_map = {tool.__name__: tool for tool in self._callable_tools}
+        
         logger.info(f"Loaded {len(self._mcp_tools)} MCP tools")
         
         # Create ACP manifest
@@ -176,9 +183,8 @@ class MCPBridgeExecutor:
             # Call MCP tool
             logger.info(f"Calling MCP tool '{tool_name}' with args: {args}")
             
-            # Get the callable tool
-            tools = await self.mcp_client.list_tools()
-            tool_func = next((t for t in tools if t.__name__ == tool_name), None)
+            # Get the callable tool from cache (O(1) lookup)
+            tool_func = self._tool_map.get(tool_name)
             
             if not tool_func:
                 raise ValueError(f"Tool {tool_name} not found in callable tools")

--- a/src/any_agent/serving/mcp_acp_bridge.py
+++ b/src/any_agent/serving/mcp_acp_bridge.py
@@ -1,0 +1,362 @@
+"""MCP to ACP Bridge for any-agent.
+
+This module provides a bridge that exposes MCP servers as ACP-compatible services,
+enabling seamless tool-to-agent communication across protocols.
+
+Following the pattern established in mcp_a2a_bridge.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any, Optional
+from uuid import uuid4
+
+from pydantic import BaseModel, Field
+
+from any_agent.logging import logger
+from any_agent.serving.server_handle import ServerHandle
+
+if TYPE_CHECKING:
+    from any_agent.config import MCPParams
+    from any_agent.tools.mcp.mcp_client import MCPClient
+
+# Check if ACP is available
+acp_available = False
+try:
+    from agntcy_acp import (
+        ACPAsyncClient,
+        Agent,
+        AgentACPDescriptor,
+        AgentACPSpec,
+        AgentCapabilities,
+        AgentMetadata,
+        RunCreateStateless,
+        RunStateless,
+        RunStatus,
+        StreamingMode,
+        StreamingModes,
+    )
+    
+    acp_available = True
+except ImportError:
+    pass
+
+
+class MCPToACPBridgeConfig(BaseModel):
+    """Configuration for MCP to ACP bridge."""
+
+    mcp_config: MCPParams
+    host: str = Field(default="localhost", description="Host to serve on")
+    port: int = Field(default=8090, description="Port to serve on")
+    endpoint: str = Field(default="/mcp-bridge", description="Endpoint path")
+    server_name: str = Field(default="mcp-server", description="MCP server name")
+    identity_id: Optional[str] = Field(
+        default=None, 
+        description="AGNTCY Identity DID for the bridge"
+    )
+    version: str = Field(default="1.0.0", description="Version of the bridge")
+    organization: str = Field(default="any-agent", description="Organization name")
+
+
+class MCPBridgeExecutor:
+    """Executor that translates ACP requests to MCP tool calls."""
+
+    def __init__(self, mcp_client: MCPClient, bridge_config: MCPToACPBridgeConfig):
+        """Initialize the executor.
+
+        Args:
+            mcp_client: Connected MCP client
+            bridge_config: Bridge configuration
+        """
+        self.mcp_client = mcp_client
+        self.bridge_config = bridge_config
+        self._mcp_tools: dict[str, Any] = {}
+        self._agent_manifest: Optional[dict[str, Any]] = None
+
+    async def initialize(self) -> None:
+        """Initialize by loading MCP tools and creating ACP manifest."""
+        raw_tools = await self.mcp_client.list_raw_tools()
+        self._mcp_tools = {tool.name: tool for tool in raw_tools}
+        logger.info(f"Loaded {len(self._mcp_tools)} MCP tools")
+        
+        # Create ACP manifest
+        self._agent_manifest = await self._create_acp_manifest()
+    
+    async def _create_acp_manifest(self) -> dict[str, Any]:
+        """Create ACP manifest from MCP tools."""
+        mcp_tools = await self.mcp_client.list_raw_tools()
+        
+        # Build tool descriptions for manifest
+        tools_description = []
+        for tool in mcp_tools:
+            tools_description.append({
+                "name": tool.name,
+                "description": tool.description or f"MCP tool: {tool.name}",
+                "inputSchema": tool.inputSchema if hasattr(tool, 'inputSchema') else {}
+            })
+        
+        manifest = {
+            "id": f"mcp-bridge-{self.bridge_config.server_name}",
+            "name": f"{self.bridge_config.server_name} MCP Bridge",
+            "version": self.bridge_config.version,
+            "description": f"MCP server '{self.bridge_config.server_name}' exposed via ACP",
+            "metadata": {
+                "organization": self.bridge_config.organization,
+                "bridge_type": "mcp-to-acp",
+                "identity_id": self.bridge_config.identity_id,
+            },
+            "acp": {
+                "version": "0.2.3",
+                "capabilities": {
+                    "stateless": True,
+                    "stateful": False,
+                    "threads": False,
+                    "callbacks": False,
+                    "streaming": StreamingModes(
+                        stateless=StreamingMode.VALUE,
+                        stateful=None
+                    ) if acp_available else {"stateless": "value", "stateful": None},
+                    "interrupts": False,
+                },
+                "input": {
+                    "type": "object",
+                    "properties": {
+                        "tool": {"type": "string", "description": "Tool name to call"},
+                        "args": {"type": "object", "description": "Tool arguments"}
+                    },
+                    "required": ["tool"]
+                },
+                "output": {
+                    "type": "object",
+                    "properties": {
+                        "result": {"description": "Tool execution result"},
+                        "error": {"type": "string", "description": "Error message if failed"}
+                    }
+                },
+                "tools": tools_description,
+            }
+        }
+        
+        return manifest
+
+    async def execute_stateless_run(self, run_request: RunCreateStateless) -> RunStateless:
+        """Execute a stateless ACP run by calling appropriate MCP tool.
+
+        Args:
+            run_request: ACP run request
+
+        Returns:
+            ACP run result
+        """
+        run_id = str(uuid4())
+        
+        try:
+            # Extract tool and args from config
+            config = run_request.config or {}
+            tool_name = config.get("tool")
+            args = config.get("args", {})
+            
+            if not tool_name:
+                # If no tool specified, try to infer from input
+                # This is a simple heuristic - could be improved
+                if len(self._mcp_tools) == 1:
+                    tool_name = list(self._mcp_tools.keys())[0]
+                    args = {"input": run_request.input} if run_request.input else {}
+                else:
+                    raise ValueError(
+                        f"Multiple tools available: {list(self._mcp_tools.keys())}. "
+                        "Please specify which tool to use in config.tool"
+                    )
+            
+            # Validate tool exists
+            if tool_name not in self._mcp_tools:
+                raise ValueError(f"Unknown tool: {tool_name}")
+            
+            # Call MCP tool
+            logger.info(f"Calling MCP tool '{tool_name}' with args: {args}")
+            
+            # Get the callable tool
+            tools = await self.mcp_client.list_tools()
+            tool_func = next((t for t in tools if t.__name__ == tool_name), None)
+            
+            if not tool_func:
+                raise ValueError(f"Tool {tool_name} not found in callable tools")
+            
+            # Execute the tool
+            result = await tool_func(**args) if asyncio.iscoroutinefunction(tool_func) else tool_func(**args)
+            
+            # Create successful run result
+            return RunStateless(
+                id=run_id,
+                status=RunStatus.completed,
+                output={
+                    "result": result,
+                    "tool": tool_name,
+                    "success": True
+                }
+            )
+            
+        except Exception as e:
+            logger.error(f"Error executing MCP tool: {e}")
+            return RunStateless(
+                id=run_id,
+                status=RunStatus.failed,
+                error={
+                    "type": "ToolExecutionError",
+                    "message": str(e)
+                },
+                output={
+                    "error": str(e),
+                    "success": False
+                }
+            )
+
+
+async def serve_mcp_as_acp_async(
+    mcp_config: MCPParams,
+    bridge_config: Optional[MCPToACPBridgeConfig] = None,
+    framework: str = "tinyagent",
+) -> ServerHandle:
+    """Serve an MCP server as an ACP service.
+
+    Args:
+        mcp_config: MCP server configuration
+        bridge_config: Bridge configuration (uses defaults if not provided)
+        framework: Agent framework to use for tool conversion
+
+    Returns:
+        ServerHandle for managing the server
+
+    Raises:
+        ImportError: If ACP dependencies are not installed
+    """
+    if not acp_available:
+        msg = "You need to `pip install 'agntcy-acp'` to use MCP to ACP bridge"
+        raise ImportError(msg)
+    
+    from any_agent.config import AgentFramework
+    from any_agent.tools.mcp.mcp_client import MCPClient
+    import uvicorn
+    from starlette.applications import Starlette
+    from starlette.routing import Route
+    from starlette.responses import JSONResponse
+    
+    # Use default config if not provided
+    if bridge_config is None:
+        bridge_config = MCPToACPBridgeConfig(mcp_config=mcp_config)
+    else:
+        # Ensure mcp_config is set
+        bridge_config.mcp_config = mcp_config
+    
+    # Create and connect MCP client
+    mcp_client = MCPClient(
+        config=mcp_config,
+        framework=AgentFramework.from_string(framework),
+    )
+    await mcp_client.connect()
+    
+    # Create executor
+    executor = MCPBridgeExecutor(mcp_client, bridge_config)
+    await executor.initialize()
+    
+    # ACP route handlers
+    async def get_agents(request):
+        """List available agents (in this case, just our bridge)."""
+        agent = Agent(
+            id=f"mcp-bridge-{bridge_config.server_name}",
+            name=f"{bridge_config.server_name} MCP Bridge",
+            description=f"MCP server '{bridge_config.server_name}' exposed via ACP",
+            metadata=AgentMetadata(
+                organization=bridge_config.organization,
+                version=bridge_config.version,
+            ),
+            acp_descriptor=executor._agent_manifest.get("acp", {}),
+        )
+        return JSONResponse([agent.model_dump()])
+    
+    async def search_agents(request):
+        """Search agents - returns our bridge if it matches."""
+        # For simplicity, always return our agent
+        return await get_agents(request)
+    
+    async def get_agent_by_id(request):
+        """Get specific agent by ID."""
+        agent_id = request.path_params["agent_id"]
+        expected_id = f"mcp-bridge-{bridge_config.server_name}"
+        
+        if agent_id != expected_id:
+            return JSONResponse({"error": "Agent not found"}, status_code=404)
+        
+        agent = Agent(
+            id=expected_id,
+            name=f"{bridge_config.server_name} MCP Bridge",
+            description=f"MCP server '{bridge_config.server_name}' exposed via ACP",
+            metadata=AgentMetadata(
+                organization=bridge_config.organization,
+                version=bridge_config.version,
+            ),
+            acp_descriptor=executor._agent_manifest.get("acp", {}),
+        )
+        return JSONResponse(agent.model_dump())
+    
+    async def create_stateless_run(request):
+        """Create a stateless run."""
+        body = await request.json()
+        run_request = RunCreateStateless(**body)
+        
+        # Execute the run
+        result = await executor.execute_stateless_run(run_request)
+        
+        return JSONResponse(result.model_dump())
+    
+    async def get_stateless_run(request):
+        """Get stateless run status - not implemented for bridge."""
+        return JSONResponse(
+            {"error": "Run history not supported in bridge mode"}, 
+            status_code=501
+        )
+    
+    # Create Starlette app with ACP routes
+    base_path = bridge_config.endpoint.rstrip("/")
+    routes = [
+        Route(f"{base_path}/agents/search", search_agents, methods=["POST"]),
+        Route(f"{base_path}/agents", get_agents, methods=["GET"]),
+        Route(f"{base_path}/agents/{{agent_id}}", get_agent_by_id, methods=["GET"]),
+        Route(f"{base_path}/runs/stateless", create_stateless_run, methods=["POST"]),
+        Route(f"{base_path}/runs/stateless/{{run_id}}", get_stateless_run, methods=["GET"]),
+    ]
+    
+    app = Starlette(routes=routes)
+    
+    # Create and start server
+    config = uvicorn.Config(
+        app,
+        host=bridge_config.host,
+        port=bridge_config.port,
+        log_level="warning",
+    )
+    server = uvicorn.Server(config)
+    
+    # Start server in background
+    task = asyncio.create_task(server.serve())
+    
+    # Wait for server to start
+    while not server.started:
+        await asyncio.sleep(0.1)
+    
+    # Get actual port if using dynamic port
+    actual_port = bridge_config.port
+    if bridge_config.port == 0 and server.servers:
+        actual_port = server.servers[0].sockets[0].getsockname()[1]
+    
+    bridge_url = f"http://{bridge_config.host}:{actual_port}{bridge_config.endpoint}"
+    
+    if bridge_config.identity_id:
+        logger.info(f"MCP to ACP bridge started at {bridge_url} with identity {bridge_config.identity_id}")
+    else:
+        logger.info(f"MCP to ACP bridge started at {bridge_url}")
+    
+    logger.info(f"ACP manifest available at: {bridge_url}/agents")
+    
+    return ServerHandle(task=task, server=server)


### PR DESCRIPTION
Lets MCP tools work with ACP's REST API.

## What It Does  

Exposes MCP servers through ACP REST endpoints.

## Example

```python
from any_agent.serving import serve_mcp_as_acp_async, MCPToACPBridgeConfig

config = MCPToACPBridgeConfig(
    mcp_command="uvx",
    mcp_args=["mcp-server-filesystem"],
    port=8090
)

await serve_mcp_as_acp_async(config)
```

Now available at:
- `GET http://localhost:8090/agents` - list tools
- `POST http://localhost:8090/runs/stateless` - run tools

## Notes

- If using mcpd identity, it shows up in API responses
- Unlike A2A, ACP supports metadata
- Needs async support from agntcy/acp-sdk#113

Part of making MCP tools work with different protocols.