### PR TITLE
Implement safe argument casting in tinyagent.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ agno = [
 ]
 
 google = [
-  "google-adk>=1.4.1, <2"
+  "google-adk>=1.4.1, <1.13.0" # Pinned until https://github.com/mozilla-ai/any-agent/issues/780
 ]
 
 langchain = [

--- a/src/any_agent/frameworks/tinyagent.py
+++ b/src/any_agent/frameworks/tinyagent.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 import asyncio
 import inspect
 import json
-import types
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any, Union, get_args, get_origin
+from typing import TYPE_CHECKING, Any
 
 from any_llm import acompletion
 from any_llm.provider import ProviderFactory, ProviderName
@@ -13,6 +12,7 @@ from mcp.types import CallToolResult, TextContent
 
 from any_agent.config import AgentConfig, AgentFramework
 from any_agent.logging import logger
+from any_agent.utils.cast import safe_cast_argument
 
 from .any_agent import AnyAgent
 
@@ -31,69 +31,6 @@ Once you have a final answer, you MUST call the `final_answer` tool.
 
 You MUST plan extensively before each function call, and reflect extensively on the outcomes of the previous function calls.
 """.strip()
-
-
-def _safe_cast_argument(value: Any, arg_type: Any) -> Any:
-    """Safely cast an argument to the specified type, handling union types.
-    
-    Args:
-        value: The value to cast
-        arg_type: The target type (may be a union type)
-        
-    Returns:
-        The cast value, or the original value if casting fails
-    """
-    # Handle None values for optional types
-    if value is None:
-        return None
-        
-    # Handle modern union types (e.g., int | str | None)
-    if isinstance(arg_type, types.UnionType):
-        union_args = get_args(arg_type)
-        # Filter out NoneType for optional parameters
-        non_none_types = [t for t in union_args if t is not type(None)]
-        
-        # If only one non-None type, try to cast to it
-        if len(non_none_types) == 1:
-            try:
-                return non_none_types[0](value)
-            except (ValueError, TypeError):
-                return value
-        
-        # For multiple types, try each one until one works
-        for cast_type in non_none_types:
-            try:
-                return cast_type(value)
-            except (ValueError, TypeError):
-                continue
-        return value
-    
-    # Handle typing.Union (older style)
-    if get_origin(arg_type) is Union:
-        union_args = get_args(arg_type)
-        # Filter out NoneType for optional parameters  
-        non_none_types = [t for t in union_args if t is not type(None)]
-        
-        # If only one non-None type, try to cast to it
-        if len(non_none_types) == 1:
-            try:
-                return non_none_types[0](value)
-            except (ValueError, TypeError):
-                return value
-                
-        # For multiple types, try each one until one works
-        for cast_type in non_none_types:
-            try:
-                return cast_type(value)
-            except (ValueError, TypeError):
-                continue
-        return value
-    
-    # Handle regular types
-    try:
-        return arg_type(value)
-    except (ValueError, TypeError):
-        return value
 
 
 class ToolExecutor:
@@ -126,7 +63,9 @@ class ToolExecutor:
                 for arg_name, arg_type in func_args.items():
                     if arg_name in arguments:
                         with suppress(Exception):
-                            arguments[arg_name] = _safe_cast_argument(arguments[arg_name], arg_type)
+                            arguments[arg_name] = safe_cast_argument(
+                                arguments[arg_name], arg_type
+                            )
 
             if asyncio.iscoroutinefunction(self.tool_function):
                 result = await self.tool_function(**arguments)

--- a/src/any_agent/frameworks/tinyagent.py
+++ b/src/any_agent/frameworks/tinyagent.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import asyncio
 import inspect
 import json
+import types
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Union, get_args, get_origin
 
 from any_llm import acompletion
 from any_llm.provider import ProviderFactory, ProviderName
@@ -30,6 +31,69 @@ Once you have a final answer, you MUST call the `final_answer` tool.
 
 You MUST plan extensively before each function call, and reflect extensively on the outcomes of the previous function calls.
 """.strip()
+
+
+def _safe_cast_argument(value: Any, arg_type: Any) -> Any:
+    """Safely cast an argument to the specified type, handling union types.
+    
+    Args:
+        value: The value to cast
+        arg_type: The target type (may be a union type)
+        
+    Returns:
+        The cast value, or the original value if casting fails
+    """
+    # Handle None values for optional types
+    if value is None:
+        return None
+        
+    # Handle modern union types (e.g., int | str | None)
+    if isinstance(arg_type, types.UnionType):
+        union_args = get_args(arg_type)
+        # Filter out NoneType for optional parameters
+        non_none_types = [t for t in union_args if t is not type(None)]
+        
+        # If only one non-None type, try to cast to it
+        if len(non_none_types) == 1:
+            try:
+                return non_none_types[0](value)
+            except (ValueError, TypeError):
+                return value
+        
+        # For multiple types, try each one until one works
+        for cast_type in non_none_types:
+            try:
+                return cast_type(value)
+            except (ValueError, TypeError):
+                continue
+        return value
+    
+    # Handle typing.Union (older style)
+    if get_origin(arg_type) is Union:
+        union_args = get_args(arg_type)
+        # Filter out NoneType for optional parameters  
+        non_none_types = [t for t in union_args if t is not type(None)]
+        
+        # If only one non-None type, try to cast to it
+        if len(non_none_types) == 1:
+            try:
+                return non_none_types[0](value)
+            except (ValueError, TypeError):
+                return value
+                
+        # For multiple types, try each one until one works
+        for cast_type in non_none_types:
+            try:
+                return cast_type(value)
+            except (ValueError, TypeError):
+                continue
+        return value
+    
+    # Handle regular types
+    try:
+        return arg_type(value)
+    except (ValueError, TypeError):
+        return value
 
 
 class ToolExecutor:
@@ -62,7 +126,7 @@ class ToolExecutor:
                 for arg_name, arg_type in func_args.items():
                     if arg_name in arguments:
                         with suppress(Exception):
-                            arguments[arg_name] = arg_type(arguments[arg_name])
+                            arguments[arg_name] = _safe_cast_argument(arguments[arg_name], arg_type)
 
             if asyncio.iscoroutinefunction(self.tool_function):
                 result = await self.tool_function(**arguments)

--- a/src/any_agent/utils/cast.py
+++ b/src/any_agent/utils/cast.py
@@ -1,0 +1,63 @@
+import types
+from typing import Any, Union, get_args, get_origin
+
+def safe_cast_argument(value: Any, arg_type: Any) -> Any:
+    """Safely cast an argument to the specified type, handling union types.
+
+    Args:
+        value: The value to cast
+        arg_type: The target type (may be a union type)
+
+    Returns:
+        The cast value, or the original value if casting fails
+
+    """
+    # Handle None values for optional types
+    if value is None:
+        return None
+
+    # Handle modern union types (e.g., int | str | None)
+    if isinstance(arg_type, types.UnionType):
+        union_args = get_args(arg_type)
+        # Filter out NoneType for optional parameters
+        non_none_types = [t for t in union_args if t is not type(None)]
+
+        if len(non_none_types) == 1:
+            try:
+                return non_none_types[0](value)
+            except (ValueError, TypeError):
+                return value
+
+        # For multiple types, try each one until one works
+        for cast_type in non_none_types:
+            try:
+                return cast_type(value)
+            except (ValueError, TypeError):
+                continue
+        return value
+
+    # Handle typing.Union (older style)
+    if get_origin(arg_type) is Union:
+        union_args = get_args(arg_type)
+        # Filter out NoneType for optional parameters
+        non_none_types = [t for t in union_args if t is not type(None)]
+
+        # If only one non-None type, try to cast to it
+        if len(non_none_types) == 1:
+            try:
+                return non_none_types[0](value)
+            except (ValueError, TypeError):
+                return value
+
+        # For multiple types, try each one until one works
+        for cast_type in non_none_types:
+            try:
+                return cast_type(value)
+            except (ValueError, TypeError):
+                continue
+        return value
+
+    try:
+        return arg_type(value)
+    except (ValueError, TypeError):
+        return value

--- a/src/any_agent/utils/cast.py
+++ b/src/any_agent/utils/cast.py
@@ -1,6 +1,7 @@
 import types
 from typing import Any, Union, get_args, get_origin
 
+
 def safe_cast_argument(value: Any, arg_type: Any) -> Any:
     """Safely cast an argument to the specified type, handling union types.
 

--- a/tests/unit/utils/test_cast.py
+++ b/tests/unit/utils/test_cast.py
@@ -1,0 +1,165 @@
+import types
+from typing import Any, Optional, Union
+
+import pytest
+
+from any_agent.utils.cast import safe_cast_argument
+
+
+def test_basic_type_casting() -> None:
+    """Test basic type casting for primitive types."""
+    assert safe_cast_argument("42", int) == 42
+    assert safe_cast_argument(42, str) == "42"
+    assert safe_cast_argument("3.14", float) == 3.14
+    assert safe_cast_argument("true", bool) == True
+    assert safe_cast_argument("false", bool) == True  # Any non-empty string is truthy
+    assert safe_cast_argument("", bool) == False
+    assert safe_cast_argument(0, bool) == False
+    assert safe_cast_argument(1, bool) == True
+
+
+def test_none_value_handling() -> None:
+    """Test that None values are handled correctly."""
+    assert safe_cast_argument(None, int) is None
+    assert safe_cast_argument(None, str) is None
+    assert safe_cast_argument(None, Optional[int]) is None
+
+
+def test_failed_casting_returns_original() -> None:
+    """Test that failed casting returns the original value."""
+    assert safe_cast_argument("invalid", int) == "invalid"
+    assert safe_cast_argument("not_a_float", float) == "not_a_float"
+    assert safe_cast_argument(object(), str) != object()  # str() works on objects
+
+
+def test_modern_union_types() -> None:
+    """Test modern union types using | syntax."""
+    # Single non-None type in union
+    union_type = int | None
+    assert safe_cast_argument("42", union_type) == 42
+    assert safe_cast_argument(None, union_type) is None
+
+    # Multiple types in union - should try each until one works
+    multi_union = int | str | None
+    assert safe_cast_argument("42", multi_union) == 42
+    assert safe_cast_argument("hello", multi_union) == "hello"
+    assert safe_cast_argument(None, multi_union) is None
+
+
+def test_typing_union_types() -> None:
+    """Test traditional typing.Union types."""
+    # Single non-None type in union
+    union_type = Union[int, None]
+    assert safe_cast_argument("42", union_type) == 42
+    assert safe_cast_argument(None, union_type) is None
+
+    # Multiple types in union
+    multi_union = Union[int, str, None]
+    assert safe_cast_argument("42", multi_union) == 42
+    assert safe_cast_argument("hello", multi_union) == "hello"
+    assert safe_cast_argument(None, multi_union) is None
+
+
+def test_optional_types() -> None:
+    """Test Optional type annotations."""
+    assert safe_cast_argument("42", Optional[int]) == 42
+    assert safe_cast_argument(None, Optional[int]) is None
+    assert safe_cast_argument("invalid", Optional[int]) == "invalid"
+
+
+def test_union_type_precedence() -> None:
+    """Test that union types try casting in order."""
+    # int should be tried before str, so "42" becomes 42
+    union_type = int | str
+    assert safe_cast_argument("42", union_type) == 42
+    assert isinstance(safe_cast_argument("42", union_type), int)
+
+    # If int casting fails, should fall back to str
+    assert safe_cast_argument("hello", union_type) == "hello"
+    assert isinstance(safe_cast_argument("hello", union_type), str)
+
+
+def test_complex_union_scenarios() -> None:
+    """Test complex union type scenarios."""
+    # Union with float and int - should prefer the first one that works
+    union_type = float | int | str
+    assert safe_cast_argument("3.14", union_type) == 3.14
+    assert isinstance(safe_cast_argument("3.14", union_type), float)
+
+    assert safe_cast_argument("42", union_type) == 42.0  # float("42") works first
+    assert isinstance(safe_cast_argument("42", union_type), float)
+
+
+def test_edge_cases() -> None:
+    """Test edge cases and boundary conditions."""
+    # Empty string
+    assert safe_cast_argument("", str) == ""
+    assert safe_cast_argument("", int) == ""  # Casting fails, returns original
+
+    # Zero values
+    assert safe_cast_argument(0, str) == "0"
+    assert safe_cast_argument("0", int) == 0
+
+    # Boolean edge cases
+    assert safe_cast_argument(True, str) == "True"
+    assert safe_cast_argument(False, str) == "False"
+    assert safe_cast_argument("True", bool) == True
+    assert safe_cast_argument("False", bool) == True  # Non-empty string is truthy
+
+
+def test_type_already_correct() -> None:
+    """Test when the value is already the correct type."""
+    assert safe_cast_argument(42, int) == 42
+    assert safe_cast_argument("hello", str) == "hello"
+    assert safe_cast_argument(3.14, float) == 3.14
+    assert safe_cast_argument(True, bool) == True
+
+
+def test_union_with_failed_casts() -> None:
+    """Test union types where some casts fail."""
+    # Create a union where int casting fails but str works
+    union_type = int | str
+    result = safe_cast_argument("not_a_number", union_type)
+    assert result == "not_a_number"
+    assert isinstance(result, str)
+
+
+def test_all_union_casts_fail() -> None:
+    """Test when all union type casts fail."""
+    # This is a bit contrived since str() usually works on most objects
+    # But we can test with a custom object that might cause issues
+    union_type = int | float
+    result = safe_cast_argument("invalid_for_both", union_type)
+    assert result == "invalid_for_both"  # Returns original value
+
+
+@pytest.mark.parametrize(
+    "value,target_type,expected",
+    [
+        ("42", int, 42),
+        ("3.14", float, 3.14),
+        (42, str, "42"),
+        ("hello", str, "hello"),
+        (None, Optional[int], None),
+        ("42", Union[int, str], 42),
+        ("hello", Union[int, str], "hello"),
+        ("invalid", int, "invalid"),
+    ],
+)
+def test_parametrized_casting(value: Any, target_type: Any, expected: Any) -> None:
+    """Parametrized test for various casting scenarios."""
+    assert safe_cast_argument(value, target_type) == expected
+
+
+def test_modern_vs_traditional_union_consistency() -> None:
+    """Test that modern and traditional union types behave consistently."""
+    modern_union = int | str | None
+    traditional_union = Union[int, str, None]
+
+    test_values = ["42", "hello", None, "invalid_int"]
+
+    for value in test_values:
+        modern_result = safe_cast_argument(value, modern_union)
+        traditional_result = safe_cast_argument(value, traditional_union)
+        assert modern_result == traditional_result
+        assert type(modern_result) == type(traditional_result)

--- a/tests/unit/utils/test_cast.py
+++ b/tests/unit/utils/test_cast.py
@@ -1,4 +1,5 @@
-import types
+# ruff: noqa: E712, E721, UP007, UP045, PT006
+
 from typing import Any, Optional, Union
 
 import pytest


### PR DESCRIPTION
Added a safe casting function to handle argument types, including union types.

Found when working in any-forge, We had some bool | None types that were silently being ignored