### PR TITLE
fix(import errors) with Otel and composio

### DIFF
--- a/.github/workflows/tests-docs.yaml
+++ b/.github/workflows/tests-docs.yaml
@@ -36,7 +36,6 @@ jobs:
       - name: Install
         run: |
           uv sync --group tests --extra all --extra a2a --extra composio
-          uv pip install opentelemetry-exporter-otlp
 
       - name: Run Documentation tests
         run: pytest tests/docs -v --cov --cov-report=xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ dependencies = [
   "litellm>=1.75.8",
   "mcp>=1.5.0",
   "opentelemetry-sdk",
-  "opentelemetry-exporter-otlp-proto-http",
   "pydantic",
   "requests",
   "rich",
@@ -194,6 +193,7 @@ tests = [
   "mktestdocs>=0.2.4",
   "syrupy>=4.9.1",
   "any-llm-sdk[anthropic,gemini,huggingface,mistral,xai]>=0.20.2,<1",
+  "opentelemetry-exporter-otlp-proto-http",
 ]
 
 # For completeness, but 'uv sync --group dev' currently installs the others too.


### PR DESCRIPTION
To replicate, try running from `main`:
```
uv sync --group tests --extra all --extra a2a --extra composio
pytest tests/docs -v
```

With Otel the error is:
```
ModuleNotFoundError: No module named 'opentelemetry.exporter.otlp'
```
And the solution was to add `opentelemetry-exporter-otlp-proto-http` based on https://github.com/microsoft/autogen/issues/6419

With Composio the error is:
```
.venv/lib/python3.11/site-packages/composio/core/models/tools.py:27: in <module>
    from composio.types import ToolkitVersionParam
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    import typing as t
    
    import typing_extensions as te
    
    from composio.client.types import Tool
    from composio.core.models.connected_accounts import auth_scheme
    from composio.core.models.custom_tools import ExecuteRequestFn
>   from composio.core.models.tools import (
        Modifiers,
        ToolExecuteParams,
        ToolExecutionResponse,
    )
E   ImportError: cannot import name 'Modifiers' from partially initialized module 'composio.core.models.tools' (most likely due to a circular import) (/Users/hareeshbahuleyan/Desktop/mzai_github/any-agent/.venv/lib/python3.11/site-packages/composio/core/models/tools.py)

.venv/lib/python3.11/site-packages/composio/types.py:8: ImportError
```

Using version <0.8.13 fixes the issue
