### PR TITLE
docs: replace underscores in README.md's "Cookbooks" links with dashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,12 @@ print(agent_trace)
 
 Get started quickly with these practical examples:
 
-- **[Creating your first agent](https://mozilla-ai.github.io/any-agent/cookbook/your_first_agent/)** - Build a simple agent with web search capabilities.
-- **[Creating your first agent evaluation](https://mozilla-ai.github.io/any-agent/cookbook/your_first_agent_evaluation/)** - Evaluate that simple web search agent using 3 different methods.
+- **[Creating your first agent](https://mozilla-ai.github.io/any-agent/cookbook/your-first-agent/)** - Build a simple agent with web search capabilities.
+- **[Creating your first agent evaluation](https://mozilla-ai.github.io/any-agent/cookbook/your-first-agent-evaluation/)** - Evaluate that simple web search agent using 3 different methods.
 - **[Using Callbacks](https://mozilla-ai.github.io/any-agent/cookbook/callbacks/)** - Implement and use custom callbacks.
-- **[Creating an agent with MCP](https://mozilla-ai.github.io/any-agent/cookbook/mcp_agent/)** - Integrate Model Context Protocol tools.
-- **[Serve an Agent with A2A](https://mozilla-ai.github.io/any-agent/cookbook/serve_a2a/)** - Deploy agents with Agent-to-Agent communication.
-- **[Building Multi-Agent Systems with A2A](https://mozilla-ai.github.io/any-agent/cookbook/a2a_as_tool/)** - Using an agent as a tool for another agent to interact with.
+- **[Creating an agent with MCP](https://mozilla-ai.github.io/any-agent/cookbook/mcp-agent/)** - Integrate Model Context Protocol tools.
+- **[Serve an Agent with A2A](https://mozilla-ai.github.io/any-agent/cookbook/serve-a2a/)** - Deploy agents with Agent-to-Agent communication.
+- **[Building Multi-Agent Systems with A2A](https://mozilla-ai.github.io/any-agent/cookbook/a2a-as-tool/)** - Using an agent as a tool for another agent to interact with.
 
 ## Contributions
 


### PR DESCRIPTION
## Description
This PR replaces underscores in the links in the "Cookbooks" section of `README.md` with dashes.

With underscores (old): attempting to access the links returns 404 errors.  
With dashes (new): attempting to acces the links returns the correct/intended pages.


## PR Type

- Documentation

## Relevant issues

(None found)

## Checklist
<!-- If this checklist is deleted from the PR submission it will be immediately closed -->
- [x] I understand the code I am submitting.
- [ ] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [ ] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-agent/blob/main/CONTRIBUTING.md)
- [ ] **AI Usage:**
    - [x] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information
<!-- We welcome the use of AI to aid in contribution! Optional: We're interested in hearing about your setup. What LLM are you using (e.g. Opus 4.5, GPT-5, Minimax), and which tooling (Claude Code, VsCode, OpenCode, etc) -->

- AI Model used:
- AI Developer Tool used:
- Any other info you'd like to share:

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)
