### PR TITLE
ci(docs): stage gitbook site outside working tree before rsync

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -50,6 +50,11 @@ jobs:
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           cp .gitbook-branch-readme.md site/README-BRANCH.md
 
+          # Stage the built site outside the working tree. Otherwise `rsync
+          # --delete` below sees `./site/` as extraneous in the destination
+          # and races to delete it while still reading from it.
+          mv site "${RUNNER_TEMP}/gitbook-site"
+
           git fetch origin gitbook-docs || true
           if git rev-parse --verify origin/gitbook-docs >/dev/null 2>&1; then
             git checkout gitbook-docs
@@ -58,7 +63,7 @@ jobs:
             git rm -rf .
           fi
 
-          rsync -a --delete site/ .
+          rsync -a --delete "${RUNNER_TEMP}/gitbook-site/" .
           git add -A
           if ! git diff --cached --quiet; then
             git commit -m "docs: update GitBook documentation from ${{ github.sha }}"


### PR DESCRIPTION
## Description

The Documentation deploy step has been failing on every push to `main` since the GitBook deploy workflow landed. Root cause: `rsync -a --delete site/ .` has the source directory living inside the destination, so `--delete` flags `./site/` as extraneous and races to delete it while still reading from it. That's the `file has vanished: site/...` and exit 24 you see in the logs.

This PR moves the built `site/` to `$RUNNER_TEMP` before checking out the `gitbook-docs` branch, so the rsync source no longer lives inside the destination.

Failing runs for reference: #937 merge https://github.com/mozilla-ai/any-agent/actions/runs/25175452767/job/73806177630, #936 merge before it. The `gitbook-docs` branch only has the one manual seed commit, no auto-deploys have ever succeeded.

## PR Type

- Infrastructure

## Relevant issues

Follows up on #937, #936.

## Checklist
- [x] I understand the code I am submitting.
- [ ] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-agent/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used for drafting/refactoring.
    - [ ] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Opus 4.7
- AI Developer Tool used: Claude Code
- Any other info you'd like to share: Diagnosis (rsync source/destination overlap with `--delete`) and patch drafted by Claude in collaboration with @njbrake.

- [ ] I am an AI Agent filling out this form (check box if true)