### PR TITLE
chore(docs): replace GitHub Pages URLs with docs.mozilla.ai/any-llm

### DIFF
--- a/docs/agents/frameworks/agno.md
+++ b/docs/agents/frameworks/agno.md
@@ -9,5 +9,5 @@ Check the reference to find additional supported `agent_args`.
 
 ## Default Model Type
 
-We use [`any_llm`](https://mozilla-ai.github.io/any-llm/) as the default model provider.
-Check the [AnyLLM documentation](https://mozilla-ai.github.io/any-llm/) for supported providers and `model_args`.
+We use [`any_llm`](https://docs.mozilla.ai/any-llm/) as the default model provider.
+Check the [AnyLLM documentation](https://docs.mozilla.ai/any-llm/) for supported providers and `model_args`.

--- a/docs/agents/frameworks/google-adk.md
+++ b/docs/agents/frameworks/google-adk.md
@@ -9,8 +9,8 @@ Check the reference to find additional supported `agent_args`.
 
 ## Default Model Type
 
-We use [`any_llm`](https://mozilla-ai.github.io/any-llm/) as the default model provider.
-Check the [AnyLLM documentation](https://mozilla-ai.github.io/any-llm/) for supported providers and `model_args`.
+We use [`any_llm`](https://docs.mozilla.ai/any-llm/) as the default model provider.
+Check the [AnyLLM documentation](https://docs.mozilla.ai/any-llm/) for supported providers and `model_args`.
 
 ## Run args
 

--- a/docs/agents/frameworks/langchain.md
+++ b/docs/agents/frameworks/langchain.md
@@ -11,8 +11,8 @@ Check the reference to find additional supported `agent_args`.
 
 ## Default Model Type
 
-We use [`any_llm`](https://mozilla-ai.github.io/any-llm/) as the default model provider.
-Check the [AnyLLM documentation](https://mozilla-ai.github.io/any-llm/) for supported providers and `model_args`.
+We use [`any_llm`](https://docs.mozilla.ai/any-llm/) as the default model provider.
+Check the [AnyLLM documentation](https://docs.mozilla.ai/any-llm/) for supported providers and `model_args`.
 
 ## Run args
 

--- a/docs/agents/frameworks/llama-index.md
+++ b/docs/agents/frameworks/llama-index.md
@@ -10,5 +10,5 @@ Check the reference to find additional supported `agent_args`.
 
 ## Default Model Type
 
-We use [`any_llm`](https://mozilla-ai.github.io/any-llm/) as the default model provider.
-Check the [AnyLLM documentation](https://mozilla-ai.github.io/any-llm/) for supported providers and `model_args`.
+We use [`any_llm`](https://docs.mozilla.ai/any-llm/) as the default model provider.
+Check the [AnyLLM documentation](https://docs.mozilla.ai/any-llm/) for supported providers and `model_args`.

--- a/docs/agents/frameworks/openai.md
+++ b/docs/agents/frameworks/openai.md
@@ -9,8 +9,8 @@ Check the reference to find additional supported `agent_args`.
 
 ## Default Model Type
 
-We use [`any_llm`](https://mozilla-ai.github.io/any-llm/) as the default model provider.
-Check the [AnyLLM documentation](https://mozilla-ai.github.io/any-llm/) for supported providers and `model_args`.
+We use [`any_llm`](https://docs.mozilla.ai/any-llm/) as the default model provider.
+Check the [AnyLLM documentation](https://docs.mozilla.ai/any-llm/) for supported providers and `model_args`.
 
 ## Run args
 

--- a/docs/agents/frameworks/smolagents.md
+++ b/docs/agents/frameworks/smolagents.md
@@ -9,8 +9,8 @@ Check the reference to find additional supported `agent_args`.
 
 ## Default Model Type
 
-We use [`any_llm`](https://mozilla-ai.github.io/any-llm/) as the default model provider.
-Check the [AnyLLM documentation](https://mozilla-ai.github.io/any-llm/) for supported providers and `model_args`.
+We use [`any_llm`](https://docs.mozilla.ai/any-llm/) as the default model provider.
+Check the [AnyLLM documentation](https://docs.mozilla.ai/any-llm/) for supported providers and `model_args`.
 
 ## Run args
 

--- a/docs/agents/models.md
+++ b/docs/agents/models.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Model configuration in `any-agent` is designed to be consistent across all supported frameworks. We use [any-llm](https://mozilla-ai.github.io/any-llm/) as the default model provider, which acts as a unified interface allowing you to use any language model from any provider with the same syntax.
+Model configuration in `any-agent` is designed to be consistent across all supported frameworks. We use [any-llm](https://docs.mozilla.ai/any-llm/) as the default model provider, which acts as a unified interface allowing you to use any language model from any provider with the same syntax.
 
 ## Configuration Parameters
 
@@ -20,4 +20,4 @@ The `api_base` parameter allows you to specify a custom API endpoint. This is us
 
 The `api_key` parameter allows you to explicitly specify an API key for authentication. By default, `any-llm` will automatically search for common environment variables (like `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.).
 
-See the [AnyLLM Provider Documentation](https://mozilla-ai.github.io/any-llm/providers/) for the complete list of supported providers.
+See the [AnyLLM Provider Documentation](https://docs.mozilla.ai/any-llm/providers/) for the complete list of supported providers.

--- a/src/any_agent/config.py
+++ b/src/any_agent/config.py
@@ -80,7 +80,7 @@ class AgentConfig(BaseModel):
     model_id: str
     """Select the underlying model used by the agent.
 
-    If you are using the default model_type (AnyLLM), you can refer to [AnyLLM Provider Docs](https://mozilla-ai.github.io/any-llm/providers/) for the list of providers and how to access them.
+    If you are using the default model_type (AnyLLM), you can refer to [AnyLLM Provider Docs](https://docs.mozilla.ai/any-llm/providers/) for the list of providers and how to access them.
     """
 
     api_base: str | None = None
@@ -161,7 +161,7 @@ class AgentConfig(BaseModel):
     model_args: MutableMapping[str, Any] | None = None
     """Pass arguments to the model instance like `temperature`, `top_k`, as well as any other provider-specific parameters.
 
-    Refer to [any-llm Completion API Docs](https://mozilla-ai.github.io/any-llm/api/completion/) for more info.
+    Refer to [any-llm Completion API Docs](https://docs.mozilla.ai/any-llm/api/completion/) for more info.
     """
 
     any_llm_args: MutableMapping[str, Any] | None = None

--- a/src/any_agent/frameworks/agno.py
+++ b/src/any_agent/frameworks/agno.py
@@ -31,7 +31,7 @@ class AnyLLM(Model):
     """A class for interacting with any-llm.
 
     any-llm allows you to use a unified interface for various LLM providers.
-    For more information, see: https://mozilla-ai.github.io/any-llm/
+    For more information, see: https://docs.mozilla.ai/any-llm/
     """
 
     id: str = "gpt-4o"

--- a/src/any_agent/frameworks/openai.py
+++ b/src/any_agent/frameworks/openai.py
@@ -73,7 +73,7 @@ class AnyllmModel(Model):
     """Enables using any model via AnyLLM.
 
     any-llm allows you to access OpenAI, Anthropic, Gemini, Mistral, and many other models.
-    See supported providers/models here: https://mozilla-ai.github.io/any-llm/providers/
+    See supported providers/models here: https://docs.mozilla.ai/any-llm/providers/
     """
 
     def __init__(


### PR DESCRIPTION
## Description

Replaces all `mozilla-ai.github.io/any-llm` links with `docs.mozilla.ai/any-llm` across markdown docs and source docstrings/comments. Companion to #935 which already updated the `any-agent` cookbook links.

All three destination URLs were verified to resolve correctly before committing.

## PR Type

- Documentation

## Relevant issues

<!-- e.g. "Fixes #123" -->

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added unit tests that prove my fix/feature works
- [x] I have run this code locally and verified it fixes the issue.
- [x] New and existing tests pass locally
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/any-agent/blob/main/CONTRIBUTING.md)
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used for drafting/refactoring.
    - [x] This is fully AI-generated.

## AI Usage Information

- AI Model used: Claude Sonnet 4.6
- AI Developer Tool used: Claude Code
- Any other info you'd like to share:

When answering questions by the reviewer, please respond yourself, do not copy/paste the reviewer comments into an AI system and paste back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)